### PR TITLE
style: remove unnecessary typings ref

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -1,4 +1,3 @@
-/// <reference path="typings/_custom.d.ts" />
 import {Component, View, bootstrap} from 'angular2/angular2';
 import {RouteConfig, RouterOutlet, RouterLink, routerInjectables} from 'angular2/router';
 

--- a/app/components/about/about.ts
+++ b/app/components/about/about.ts
@@ -1,4 +1,3 @@
-/// <reference path="../../typings/_custom.d.ts" />
 import {Component, View, NgFor} from 'angular2/angular2';
 
 import {NamesList} from '../../services/NameList';

--- a/app/components/home/home.ts
+++ b/app/components/home/home.ts
@@ -1,4 +1,3 @@
-/// <reference path="../../typings/_custom.d.ts" />
 import {Component, View} from 'angular2/angular2';
 import {RouterLink} from 'angular2/router';
 

--- a/app/init.ts
+++ b/app/init.ts
@@ -1,4 +1,3 @@
-/// <reference path="typings/_custom.d.ts" />
 System.config({
   baseURL: '<%= APP_BASE %>',
   paths: {'*': '*.js?v=<%= VERSION %>'}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,6 @@
         "./app/typings/systemjs.d.ts",
         "./tsd_typings/angular2/angular2.d.ts",
         "./tsd_typings/angular2/router.d.ts",
-        "./tsd_typings/custom.system.d.ts",
         "./tsd_typings/es6-promise/es6-promise.d.ts",
         "./tsd_typings/rx/rx-lite.d.ts",
         "./tsd_typings/rx/rx.d.ts",


### PR DESCRIPTION
As all typings are well referenced in the `tsconfig.js` file, references in each `*.ts` files is useless.