### PR TITLE
chore: we can now use systemjs.d.ts from definitelytyped

### DIFF
--- a/app/typings/_custom.d.ts
+++ b/app/typings/_custom.d.ts
@@ -1,7 +1,7 @@
 /*
- * Our custom types
+ * Your custom types
+ * Place references (from ./app/typings) to any custom typings you need here
  */
-/// <reference path="systemjs.d.ts" />
 
 
 /*

--- a/tsd.json
+++ b/tsd.json
@@ -19,6 +19,9 @@
     },
     "angular2/router.d.ts": {
       "commit": "f6c8ca47193fb67947944a3170912672ac3e908e"
+    },
+    "systemjs/systemjs.d.ts": {
+      "commit": "bd03c6ea51abde7d13e354908716c6373fc38b1f"
     }
   }
 }

--- a/tsd_typings/systemjs/systemjs.d.ts
+++ b/tsd_typings/systemjs/systemjs.d.ts
@@ -18,4 +18,4 @@ declare var System: System;
 
 declare module "systemjs" {
   export = System;
-} 
+}

--- a/tsd_typings/tsd.d.ts
+++ b/tsd_typings/tsd.d.ts
@@ -3,3 +3,4 @@
 /// <reference path="es6-promise/es6-promise.d.ts" />
 /// <reference path="rx/rx-lite.d.ts" />
 /// <reference path="rx/rx.d.ts" />
+/// <reference path="systemjs/systemjs.d.ts" />


### PR DESCRIPTION
We can now use systemjs.d.ts from definitelytyped and can remove the customization since it's no longer needed.

https://github.com/mgechev/angular2-seed/issues/47