### PR TITLE
Update to angular2-alpha34

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -7,7 +7,7 @@ import {NamesList} from './services/NameList';
 
 @Component({
   selector: 'app',
-  viewInjector: [NamesList]
+  bindings: [NamesList]
 })
 @RouteConfig([
   { path: '/', component: Home, as: 'home' },

--- a/app/init.ts
+++ b/app/init.ts
@@ -3,6 +3,21 @@ System.config({
   paths: {'*': '*.js?v=<%= VERSION %>'}
 });
 
+// Patching System.js
+System['import'] = function (name:string, options:any):any {
+  return System.originalSystem.import.call(this, name, options).then(function(module) {
+    return module;
+  });
+};
+
+// Dirty workaround in order to load angular2/router properly
+System.import('angular2/router').then(m => {
+  System.defined['angular2/router'] = { normalizedDeps: [] };
+  System.defined['angular2/router'].module = {};
+  System.defined['angular2/router'].module.exports = m;
+});
+
+
 System.import('app')
   .catch(e => console.error(e,
     'Report this error at https://github.com/mgechev/angular2-seed/issues'));

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "~1.5.3"
   },
   "dependencies": {
-    "angular2": "2.0.0-alpha.33",
+    "angular2": "2.0.0-alpha.34",
     "es6-module-loader": "^0.15.0",
     "systemjs": "^0.16.0",
     "zone.js": "^0.4.1",


### PR DESCRIPTION
There's a workaround with System.js in order to make it work. It shouldn't be necessary when alpha35 is relased.