### PR TITLE
Fixed wrong use of path.join() in gulpfile clean.app.dev task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,7 +106,7 @@ gulp.task('clean.dev', function(done) {
 
 gulp.task('clean.app.dev', function(done) {
 // TODO: rework this part.
-  del([join(PATH.dest.dev.all, '**/*'), join('!', PATH.dest.dev.lib)
+  del([join(PATH.dest.dev.all, '**/*'), '!' + PATH.dest.dev.lib
     , '!' + join(PATH.dest.dev.lib, '*')], done);
 });
 


### PR DESCRIPTION
path.join() was being used to concatenate a gulp excluding `'!'` with a path, resulting in the PATH.dest.dev.lib folder being deleted when serving dev.
This fix removes the wrong path.join() in favor of simple string concatenation.