### PR TITLE
fix(build): make it compatible with npm3

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ var express = require('express');
 var serveStatic = require('serve-static');
 var openResource = require('open');
 
-var tinylr = require('tiny-lr')();
+var minilr = require('mini-lr')();
 var connectLivereload = require('connect-livereload');
 
 // --------------
@@ -61,7 +61,7 @@ var PATH = {
     all: APP_SRC,
     lib: [
       // Order is quite important here for the HTML tag injection.
-      require.resolve('angular2/node_modules/traceur/bin/traceur-runtime.js'),
+      require.resolve('traceur/bin/traceur-runtime.js'),
       require.resolve('es6-module-loader/dist/es6-module-loader-sans-promises.js'),
       require.resolve('es6-module-loader/dist/es6-module-loader-sans-promises.js.map'),
       require.resolve('reflect-metadata/Reflect.js'),
@@ -221,7 +221,7 @@ gulp.task('serve.dev', ['build.dev', 'livereload'], function () {
 // Livereload.
 
 gulp.task('livereload', function () {
-  tinylr.listen(LIVE_RELOAD_PORT);
+  minilr.listen(LIVE_RELOAD_PORT);
 });
 
 // --------------
@@ -229,7 +229,7 @@ gulp.task('livereload', function () {
 
 function notifyLiveReload(e) {
   var fileName = e.path;
-  tinylr.changed({
+  minilr.changed({
     body: {
       files: [fileName]
     }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "serve-static": "^1.9.2",
     "stream-series": "^0.1.1",
     "systemjs-builder": "^0.13.6",
-    "tiny-lr": "^0.1.6",
+    "mini-lr": "^0.1.6",
+    "traceur": "0.0.91",
     "tsd": "^0.6.4",
     "typescript": "~1.6.0",
     "yargs": "^3.25.0"


### PR DESCRIPTION
Two fixes:
- `require.resolve` cant find module `traceur` when npm 3.3.3 is used
- move from `tiny-lr` to `mini-lr`