### PR TITLE
Problem with slashes after using require.resolve

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,7 @@ var del = require('del');
 var fs = require('fs');
 var path = require('path');
 var join = path.join;
+var slash = require('slash');
 var karma = require('karma').server;
 var runSequence = require('run-sequence');
 var series = require('stream-series');
@@ -247,7 +248,7 @@ function transformPath(env) {
 
 function injectableDevAssetsRef() {
   var src = PATH.src.lib.map(function (path) {
-    return join(PATH.dest.dev.lib, path.split('/').pop());
+    return join(PATH.dest.dev.lib, slash(path).split('/').pop());
   });
   return src;
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "angular2": "2.0.0-alpha.37",
     "es6-module-loader": "^0.15.0",
     "reflect-metadata": "0.1.0",
+    "slash": "~1.0.0",
     "systemjs": "^0.18.17"
   }
 }


### PR DESCRIPTION
1. On windows, there's problem with require.resolve, which resolve to path with `\`. Gulp is not able to split it by `/`, and therefore unable to inject lib scripts.