### PR TITLE
Replace tiny-lr with mini-lr for npm v3 support

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,7 @@ var express = require('express');
 var serveStatic = require('serve-static');
 var openResource = require('open');
 
-var tinylr = require('tiny-lr')();
+var minilr = require('mini-lr')();
 var connectLivereload = require('connect-livereload');
 
 // --------------
@@ -222,7 +222,7 @@ gulp.task('serve.dev', ['build.dev', 'livereload'], function () {
 // Livereload.
 
 gulp.task('livereload', function () {
-  tinylr.listen(LIVE_RELOAD_PORT);
+  minilr.listen(LIVE_RELOAD_PORT);
 });
 
 // --------------
@@ -230,7 +230,7 @@ gulp.task('livereload', function () {
 
 function notifyLiveReload(e) {
   var fileName = e.path;
-  tinylr.changed({
+  minilr.changed({
     body: {
       files: [fileName]
     }

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "karma": "~0.12.37",
     "karma-chrome-launcher": "~0.2.0",
     "karma-jasmine": "~0.3.6",
+    "mini-lr": "^0.1.8",
     "open": "0.0.5",
     "run-sequence": "^1.1.0",
     "serve-static": "^1.9.2",
     "stream-series": "^0.1.1",
     "systemjs-builder": "^0.13.6",
-    "tiny-lr": "^0.1.6",
     "tsd": "^0.6.4",
     "typescript": "~1.6.0",
     "yargs": "^3.25.0"


### PR DESCRIPTION
Fixes #89 

`tiny-lr` has seemingly been abandoned, and not for the first time, so I decided to take initiative and fork the project to release the npm v3-compatible version under a different name, `mini-lr`, so that angular2-seed and the many other projects starting to run into this problem can be unblocked quickly and not have to wait for the maintainers to maybe eventually come back and cut another release in a couple months.  You can see more info about this in the mini-lr readme.