### PR TITLE
Add system-polyfills file to the lib/ dist directory

### DIFF
--- a/tools/workflow.config.js
+++ b/tools/workflow.config.js
@@ -34,6 +34,7 @@ var PATH = {
       require.resolve('reflect-metadata/Reflect.js'),
       require.resolve('reflect-metadata/Reflect.js.map'),
       require.resolve('systemjs/dist/system.src.js'),
+      require.resolve('systemjs/dist/system-polyfills.js'),
       APP_SRC + '/system.config.js',
       ANGULAR_BUNDLES + '/angular2.dev.js',
       ANGULAR_BUNDLES + '/router.dev.js',


### PR DESCRIPTION
system-polyfills.js might be included by some browsers (i.e. IE) and SystemJS tries to load it from lib/ directory.