### PR TITLE
#132: fix npm install dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
     "ts-node": "^0.2.4",
     "tsd": "^0.6.4",
     "typescript": "~1.6.0",
+    "typescript-node": "^0.1.3",
+    "typescript-register": "^1.1.0",
+    "typescript-require": "^0.2.9-1",
     "yargs": "^3.25.0"
   },
   "dependencies": {

--- a/tools/preinstall.js
+++ b/tools/preinstall.js
@@ -22,6 +22,29 @@ exec('tsd install', function (err, stdout) {
   console.log(stdout);
 });
 
+// clean npm cache.
+exec('npm cache clean', function (err, stdout) {
+  if (err) return console.log(err);
+  console.log(stdout);
+});
+
+// Install ts-node.
+exec('npm install ts-node', function (err, stdout) {
+  if (err) return console.log(err);
+  console.log(stdout);
+});
+
+// Install typescript-register.
+exec('npm install typescript-register', function (err, stdout) {
+  if (err) return console.log(err);
+  console.log(stdout);
+});
+
+// Install typescript-node.
+exec('npm install typescript-require', function (err, stdout) {
+  if (err) return console.log(err);
+  console.log(stdout);
+});
 
 function deleteFolder(path, cb) {
   if (!fs.existsSync(path)) return;

--- a/tools/preinstall.js
+++ b/tools/preinstall.js
@@ -40,7 +40,7 @@ exec('npm install typescript-register', function (err, stdout) {
   console.log(stdout);
 });
 
-// Install typescript-node.
+// Install typescript-require.
 exec('npm install typescript-require', function (err, stdout) {
   if (err) return console.log(err);
   console.log(stdout);


### PR DESCRIPTION
Fix for issue #132 
In the package.json,  "typescript-node": "^0.1.3" is deprecated, but there is a dependency requiring it. This may be due strictly to my environment?

My environment specs:
Node: v4.1.1
npm: 3.3.6

I testest by removing the node_modules folder,
run npm install
run gulp serve.dev