### PR TITLE
es6-module-loader, systemjs dependencies bump

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function(config) {
       'node_modules/zone.js/dist/zone-microtask.js',
       'node_modules/zone.js/dist/long-stack-trace-zone.js',
       'node_modules/zone.js/dist/jasmine-patch.js',
-      'node_modules/es6-module-loader/dist/es6-module-loader-sans-promises.src.js',
+      'node_modules/es6-module-loader/dist/es6-module-loader.js',
       'node_modules/systemjs/dist/system.src.js',
       'node_modules/reflect-metadata/Reflect.js',
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "serve-static": "^1.9.2",
     "slash": "~1.0.0",
     "stream-series": "^0.1.1",
-    "systemjs-builder": "^0.13.6",
+    "systemjs-builder": "^0.14.8",
     "ts-node": "^0.2.4",
     "tsd": "^0.6.4",
     "typescript": "~1.6.0",
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "angular2": "2.0.0-alpha.40",
-    "es6-module-loader": "^0.15.0",
-    "systemjs": "^0.18.17"
+    "es6-module-loader": "^0.17.8",
+    "systemjs": "^0.19.4"
   }
 }

--- a/tools/workflow.config.ts
+++ b/tools/workflow.config.ts
@@ -27,8 +27,8 @@ const PATH = {
     all: APP_SRC,
     lib_inject: [
       // Order is quite important here for the HTML tag injection.
-      require.resolve('es6-module-loader/dist/es6-module-loader-sans-promises.js'),
-      require.resolve('es6-module-loader/dist/es6-module-loader-sans-promises.js.map'),
+      require.resolve('es6-module-loader/dist/es6-module-loader.js'),
+      require.resolve('es6-module-loader/dist/es6-module-loader.js.map'),
       require.resolve('reflect-metadata/Reflect.js'),
       require.resolve('reflect-metadata/Reflect.js.map'),
       require.resolve('systemjs/dist/system.src.js'),


### PR DESCRIPTION
Seems like everything works fine after the upgrade.

All references to `es6-module-loader-sans-promises.js` renamed to `es6-module-loader.js`.