### PR TITLE
Allow .spec.js and _spec.js files for writing tests

### DIFF
--- a/test-main.js
+++ b/test-main.js
@@ -42,7 +42,7 @@ System.import('angular2/src/core/dom/browser_adapter').then(function(browser_ada
 
 
 function onlySpecFiles(path) {
-  return /_spec\.js$/.test(path);
+  return /[\.|_]spec\.js$/.test(path);
 }
 
 // Normalize paths to module names.

--- a/tools/tasks/build.js.dev.ts
+++ b/tools/tasks/build.js.dev.ts
@@ -9,7 +9,7 @@ export = function (gulp, plugins) {
     var result = gulp.src(
       [
         join(PATH.src.all, '**/*ts'),
-        '!' + join(PATH.src.all, '**/*_spec.ts')
+        '!' + join(PATH.src.all, '**/*[\.|_]spec.ts')
       ])
       .pipe(plugins.plumber())
       .pipe(plugins.inlineNg2Template({ base: APP_SRC }))


### PR DESCRIPTION
Many people use Xyz.spec.js for their test files - with this change
we support both, *.spec.js and *_spec.js.