### PR TITLE
Circleci test setup

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  node:
+    version: 4.1.0
+
+  post:
+     - npm update -g npm
+     - npm --version
+
+dependencies:
+  cache_directories:
+    - "node_modules"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -87,7 +87,7 @@ module.exports = function(config) {
     singleRun: false
   });
 
-  if (process.env.TRAVIS) {
+  if (process.env.TRAVIS || process.env.CIRCLECI) {
     config.browsers = ['Chrome_travis_ci'];
     config.singleRun = true;
   }


### PR DESCRIPTION
It could add value to users of the seed project, that they can easily setup build on CircleCI

* [x] added circle.yml configuration
* [x] modified karma.config so that it runs Chrome (same as Travis)

**A note on Headless PhantomJS**: Making the build to run headless PhantomJS2 is not working for me (but is also a topic for a separate issue/PR)

In case you are interested, here is the passing CircleCI build for the fix 
https://circleci.com/gh/jesperronn/angular2-seed/9 