### PR TITLE
Fix for IntelliJ

### DIFF
--- a/tools/utils/tasks-tools.ts
+++ b/tools/utils/tasks-tools.ts
@@ -35,7 +35,7 @@ function scanDir(root: string, cb: (taskname: string) => void) {
         path = file;
         walk(curPath);
       }
-      if (lstatSync(curPath).isFile()) {
+      if (lstatSync(curPath).isFile() && file.endsWith('.ts')) {
         let taskname = file.replace(/(\.ts)/, '');
         cb(taskname);
       }


### PR DESCRIPTION
IntelliJ transpiles to the local directory, which causes restarts on the gulp build to fail. This fixes the problem.