### PR TITLE
If npm install fails, use "npm run reinstall" to ensure we start at clean slate

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It is something similar to the AngularJS Quick Start but does the entire build w
 ```bash
 git clone https://github.com/mgechev/angular2-seed.git
 cd angular2-seed
-npm install   # clean npm cache & delete node_modules folder if you get an error
+npm install   # or `npm run reinstall` if you get an error
 npm start     # start with --env dev
 ```
 _Does not rely on any global dependencies._

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "karma.start": "karma start",
     "lint": "gulp tslint",
     "postinstall": "tsd reinstall --clean && tsd link && tsd rebundle && gulp postinstall",
+    "reinstall": "npm cache clean && rm -rf node_modules && npm install",
     "start": "gulp serve --env dev",
     "serve.dev": "gulp serve --env dev",
     "tasks.list": "gulp --tasks-simple",


### PR DESCRIPTION
This addresses issue #158, but only when you are in trouble.

This approach has a tradeoff: Firstly it is not done automatically, which requires the use to think after being in trouble

On the other hand, this approach saves time since a full clearing of caches and installation of all modules takes time.

Furthermore, adding the command as "npm run reinstall" makes it explicit what should and could be done