### PR TITLE
fixing issue that prevents more than one test using Router

### DIFF
--- a/app/components/app/app_spec.ts
+++ b/app/components/app/app_spec.ts
@@ -17,20 +17,21 @@ import {AppCmp} from './app';
 
 export function main() {
 
-  // Support for testing component that uses Router
-  beforeEachProviders(() => [
-    RouteRegistry,
-    DirectiveResolver,
-    provide(Location, {useClass: SpyLocation}),
-    provide(Router,
-      {
-        useFactory:
-          (registry, location) => { return new RootRouter(registry, location, AppCmp); },
-        deps: [RouteRegistry, Location]
-      })
-  ]);
-
   describe('App component', () => {
+
+    // Support for testing component that uses Router
+    beforeEachProviders(() => [
+      RouteRegistry,
+      DirectiveResolver,
+      provide(Location, {useClass: SpyLocation}),
+      provide(Router,
+        {
+          useFactory:
+            (registry, location) => { return new RootRouter(registry, location, AppCmp); },
+          deps: [RouteRegistry, Location]
+        })
+    ]);
+
     it('should work',
       injectAsync([TestComponentBuilder], (tcb: TestComponentBuilder) => {
         return tcb.overrideTemplate(TestComponent, '<div><app></app></div>')


### PR DESCRIPTION
Moving beforeEachProviders() from global scope, where it only makes sense to have one, to inside the describe. Then other tests can have their own beforeEachProviders() inside their describes and Jasmine will take care of cleaning up the installed providers after the describe has been run.