### PR TITLE
Prevents dist, doc, lib, .. dirs from being excluded from node_modules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,10 +30,11 @@ node_modules
 
 #IntelliJ configuration files
 .idea
+.iml
 
-dist
-dev
-docs
-lib
-test
-tools/typings/tsd
+/dist
+/dev
+/docs
+/lib
+/test
+/tools/typings/tsd


### PR DESCRIPTION
In case you want to commit node_modules, the existing excludes (dist, lib, etc...) are problematic because they also exclude these dirs inside node modules.