### PR TITLE
Fix paths for windows

### DIFF
--- a/tools/utils/template-injectables.ts
+++ b/tools/utils/template-injectables.ts
@@ -19,6 +19,6 @@ export function registerInjectableAssetsRef(paths: string[], target: string = ''
 export function transformPath(plugins, env) {
   return function (filepath) {
     arguments[0] = join(APP_BASE, filepath);
-    return plugins.inject.transform.apply(plugins.inject.transform, arguments);
+    return slash(plugins.inject.transform.apply(plugins.inject.transform, arguments));
   };
 }


### PR DESCRIPTION
Hello,

I get wrong paths on windows & firefox (chrome doesn't care) because the index.html tries to load files with backslashes instead of regular slashes.

Looking at the gulpfiles, the problem is here: https://github.com/mgechev/angular2-seed/blob/master/tools/utils/template-injectables.ts#L22

This returns:
```html
<script src="\node_modules\zone.js\dist\zone.js"></script>
<script src="\node_modules\es6-shim\es6-shim.min.js"></script>
<script src="\node_modules\reflect-metadata\Reflect.js"></script>
<script src="\node_modules\systemjs\dist\system.src.js"></script>
```

when it should return:
```html
<script src="/node_modules/zone.js/dist/zone.js"></script>
<script src="/node_modules/es6-shim/es6-shim.min.js"></script>
<script src="/node_modules/reflect-metadata/Reflect.js"></script>
<script src="/node_modules/systemjs/dist/system.src.js"></script>
```

This PR fixes this.