### PR TITLE
Update to angular Alpha 48 (broken)

### DIFF
--- a/app/components/about/about_spec.ts
+++ b/app/components/about/about_spec.ts
@@ -6,7 +6,7 @@ import {
   it
 } from 'angular2/testing';
 import {Component, View} from 'angular2/angular2';
-import {DOM} from 'angular2/src/core/dom/dom_adapter';
+import {DOM} from 'angular2/src/platform/dom/dom_adapter';
 import {AboutCmp} from './about';
 import {NameList} from '../../services/name_list';
 

--- a/app/components/app/app_spec.ts
+++ b/app/components/app/app_spec.ts
@@ -12,7 +12,7 @@ import {Location, Router, RouteRegistry} from 'angular2/router';
 import {SpyLocation} from 'angular2/src/mock/location_mock';
 import {RootRouter} from 'angular2/src/router/router';
 
-import {DOM} from 'angular2/src/core/dom/dom_adapter';
+import {DOM} from 'angular2/src/platform/dom/dom_adapter';
 import {AppCmp} from './app';
 
 export function main() {

--- a/app/components/home/home_spec.ts
+++ b/app/components/home/home_spec.ts
@@ -6,7 +6,7 @@ import {
   it,
 } from 'angular2/testing';
 import {Component, View} from 'angular2/angular2';
-import {DOM} from 'angular2/src/core/dom/dom_adapter';
+import {DOM} from 'angular2/src/platform/dom/dom_adapter';
 import {HomeCmp} from './home';
 
 export function main() {

--- a/app/typings.d.ts
+++ b/app/typings.d.ts
@@ -1,4 +1,3 @@
 // TODO: Fix TS compiler error. Improve tsProjectFn.
 // It should reference definitions from ./tsd_typings directly
 /// <reference path="../tools/typings/tsd/tsd.d.ts" />
-/// <reference path="../tools/typings/ng2_test.d.ts" />

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,7 +26,7 @@ module.exports = function(config) {
       'node_modules/reflect-metadata/Reflect.js',
 
       { pattern: 'node_modules/angular2/**/*.js', included: false, watched: false },
-      { pattern: 'node_modules/@reactivex/rxjs/dist/**/*.js', included: false, watched: false },
+      { pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false },
       { pattern: 'test/**/*.js', included: false, watched: true },
       { pattern: 'node_modules/systemjs/dist/system-polyfills.js', included: false, watched: false }, // PhantomJS2 (and possibly others) might require it
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "zone.js": "^0.5.8"
   },
   "dependencies": {
-    "angular2": "^2.0.0-alpha.48",
+    "angular2": "2.0.0-alpha.48",
     "bootstrap": "^3.3.5",
     "es6-module-loader": "^0.17.8",
     "es6-shim": "^0.33.6",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "zone.js": "^0.5.8"
   },
   "dependencies": {
-    "angular2": "2.0.0-alpha.46",
+    "angular2": "^2.0.0-alpha.47",
     "bootstrap": "^3.3.5",
     "es6-module-loader": "^0.17.8",
     "es6-shim": "^0.33.6",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "author": "Minko Gechev <mgechev>",
   "license": "MIT",
   "devDependencies": {
-    "@reactivex/rxjs": "^5.0.0-alpha.6",
     "async": "^1.4.2",
     "connect-livereload": "^0.5.3",
     "del": "^1.1.1",
@@ -76,7 +75,7 @@
     "zone.js": "^0.5.8"
   },
   "dependencies": {
-    "angular2": "^2.0.0-alpha.47",
+    "angular2": "^2.0.0-alpha.48",
     "bootstrap": "^3.3.5",
     "es6-module-loader": "^0.17.8",
     "es6-shim": "^0.33.6",

--- a/test-main.js
+++ b/test-main.js
@@ -16,7 +16,7 @@ System.config({
   }
 });
 
-System.import('angular2/src/core/dom/browser_adapter').then(function(browser_adapter) {
+System.import('angular2/src/platform/browser/browser_adapter').then(function(browser_adapter) {
   browser_adapter.BrowserDomAdapter.makeCurrent();
 }).then(function() {
   return Promise.all(

--- a/test-main.js
+++ b/test-main.js
@@ -12,7 +12,7 @@ System.config({
   defaultJSExtensions: true,
   paths: {
     'angular2/*': 'node_modules/angular2/*.js',
-    '@reactivex/rxjs/*': 'node_modules/@reactivex/rxjs/*.js'
+    'rxjs/*': 'node_modules/rxjs/*.js'
   }
 });
 

--- a/tools/typings/ng2_test.d.ts
+++ b/tools/typings/ng2_test.d.ts
@@ -1,8 +1,0 @@
-// Very bad one but fix compiler complaints.
-declare module ng {
-  var DOM: any;
-}
-
-declare module "angular2/src/core/dom/dom_adapter" {
-  export = ng;
-}


### PR DESCRIPTION
This breaks since tests cannot find "rxjs/operators/toPromise" which
changed to "rxjs/operator/toPromise" (singular)

Also, only 2 tests run right now, which also must be fixed

I believe that the first fix requires a new Angular release.
See angular/angular#5641 for discussion