### PR TITLE
Add fancier error message when npm or node are not required version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@reactivex/rxjs": "^5.0.0-alpha.6",
     "async": "^1.4.2",
+    "chalk": "^1.1.1",
     "connect-livereload": "^0.5.3",
     "del": "^1.1.1",
     "express": "~4.13.1",

--- a/tools/tasks/check.versions.ts
+++ b/tools/tasks/check.versions.ts
@@ -1,5 +1,10 @@
 import {VERSION_NPM, VERSION_NODE} from '../config';
 
+function reportError(message: string) {
+  console.error(require('chalk').white.bgRed.bold(message));
+  process.exit(1);
+}
+
 export = function check(gulp, plugins) {
   return function () {
     let exec = require('child_process').exec;
@@ -8,22 +13,22 @@ export = function check(gulp, plugins) {
     exec('npm --version',
       function (error, stdout, stderr) {
         if (error !== null) {
-          throw new Error('npm preinstall error: ' + error + stderr);
+          reportError('npm preinstall error: ' + error + stderr);
         }
 
         if (!semver.gte(stdout, VERSION_NPM)) {
-          throw new Error('NPM is not in required version! Required is ' + VERSION_NPM + ' and you\'re using ' + stdout);
+          reportError('NPM is not in required version! Required is ' + VERSION_NPM + ' and you\'re using ' + stdout);
         }
       });
 
     exec('node --version',
       function (error, stdout, stderr) {
         if (error !== null) {
-          throw new Error('npm preinstall error: ' + error + stderr);
+          reportError('npm preinstall error: ' + error + stderr);
         }
 
         if (!semver.gte(stdout, VERSION_NODE)) {
-          throw new Error('NODE is not in required version! Required is ' + VERSION_NODE + ' and you\'re using ' + stdout);
+          reportError('NODE is not in required version! Required is ' + VERSION_NODE + ' and you\'re using ' + stdout);
         }
       });
   };

--- a/tools/utils/tasks-tools.ts
+++ b/tools/utils/tasks-tools.ts
@@ -29,16 +29,18 @@ function scanDir(root: string, cb: (taskname: string) => void) {
   walk(root);
 
   function walk(path) {
-    readdirSync(path).forEach(function(file) {
+    let files = readdirSync(path);
+    for (let i = 0; i < files.length; i += 1) {
+      let file = files[i];
       let curPath = join(path, file);
       if (lstatSync(curPath).isDirectory()) { // recurse
         path = file;
         walk(curPath);
       }
-      if (lstatSync(curPath).isFile() && file.endsWith('.ts')) {
+      if (lstatSync(curPath).isFile() && /\.ts$/.test(file)) {
         let taskname = file.replace(/(\.ts)/, '');
         cb(taskname);
       }
-    });
+    }
   }
 }


### PR DESCRIPTION
Two changes:
- Made the code in `walk` compatible with older versions of node (in order to allow the user to see the error message).
- Add chalk for cleaner error message that the current node or npm version is not supported.

![](https://i.imgur.com/9dxrNEI.png)