### PR TITLE
Load only necessary task files

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -1,11 +1,5 @@
 import * as gulp from 'gulp';
-import * as runSequence from 'run-sequence';
-import {loadTasks, task} from './tools/utils';
-
-
-// --------------
-// Configuration.
-loadTasks();
+import {runSequence, task} from './tools/utils';
 
 // --------------
 // Clean (override).
@@ -13,6 +7,8 @@ gulp.task('clean',       task('clean', 'all'));
 gulp.task('clean.dist',  task('clean', 'dist'));
 gulp.task('clean.test',  task('clean', 'test'));
 gulp.task('clean.tmp',   task('clean', 'tmp'));
+
+gulp.task('check.versions', task('check.versions'));
 
 // --------------
 // Postinstall.

--- a/tools/utils/tasks_tools.ts
+++ b/tools/utils/tasks_tools.ts
@@ -21,7 +21,7 @@ export function task(taskname: string, option?: string) {
 
 export function runSequence(...sequence: any[]) {
   let tasks = [];
-  let _sequence = sequence;
+  let _sequence = sequence.slice(0);
   sequence.pop();
 
   scanDir(TASKS_PATH, taskname => tasks.push(taskname));

--- a/tools/utils/tasks_tools.ts
+++ b/tools/utils/tasks_tools.ts
@@ -2,19 +2,35 @@ import * as gulp from 'gulp';
 import * as util from 'gulp-util';
 import * as chalk from 'chalk';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
+import * as _runSequence from 'run-sequence';
 import {readdirSync, existsSync, lstatSync} from 'fs';
 import {join} from 'path';
 import {TOOLS_DIR} from '../config';
 
 const TASKS_PATH = join(TOOLS_DIR, 'tasks');
 
-export function loadTasks(): void {
-  scanDir(TASKS_PATH, (taskname) => registerTask(taskname));
-}
+// NOTE: Remove if no issues with runSequence function below.
+// export function loadTasks(): void {
+//   scanDir(TASKS_PATH, (taskname) => registerTask(taskname));
+// }
 
 export function task(taskname: string, option?: string) {
-  util.log('Loading task', chalk.yellow(taskname, option));
+  util.log('Loading task', chalk.yellow(taskname, option || ''));
   return require(join('..', 'tasks', taskname))(gulp, gulpLoadPlugins(), option);
+}
+
+export function runSequence(...sequence: any[]) {
+  let tasks = [];
+  let _sequence = sequence;
+  sequence.pop();
+
+  scanDir(TASKS_PATH, taskname => tasks.push(taskname));
+
+  sequence.forEach(task => {
+    if (tasks.indexOf(task) > -1) { registerTask(task); }
+  });
+
+  return _runSequence(..._sequence);
 }
 
 // ----------
@@ -35,10 +51,10 @@ function scanDir(root: string, cb: (taskname: string) => void) {
     for (let i = 0; i < files.length; i += 1) {
       let file = files[i];
       let curPath = join(path, file);
-      if (lstatSync(curPath).isDirectory()) { // recurse
-        path = file;
-        walk(curPath);
-      }
+      // if (lstatSync(curPath).isDirectory()) { // recurse
+      //   path = file;
+      //   walk(curPath);
+      // }
       if (lstatSync(curPath).isFile() && /\.ts$/.test(file)) {
         let taskname = file.replace(/(\.ts)/, '');
         cb(taskname);


### PR DESCRIPTION
* Improve build start by just loading the required tasks.
* Single tasks like `check.versions` now needs to be explicitly declared in gulpfile (as not all the tasks file are loaded on start).