### PR TITLE
Lazy load gulp tasks

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -1,5 +1,10 @@
 import * as gulp from 'gulp';
-import {runSequence, task} from './tools/utils';
+import * as runSequence from 'run-sequence';
+import {loadTasks, task} from './tools/utils';
+
+// --------------
+// Configuration.
+loadTasks();
 
 // --------------
 // Clean (override).
@@ -7,8 +12,6 @@ gulp.task('clean',       task('clean', 'all'));
 gulp.task('clean.dist',  task('clean', 'dist'));
 gulp.task('clean.test',  task('clean', 'test'));
 gulp.task('clean.tmp',   task('clean', 'tmp'));
-
-gulp.task('check.versions', task('check.versions'));
 
 // --------------
 // Postinstall.

--- a/tools/utils/tasks_tools.ts
+++ b/tools/utils/tasks_tools.ts
@@ -2,35 +2,21 @@ import * as gulp from 'gulp';
 import * as util from 'gulp-util';
 import * as chalk from 'chalk';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
-import * as _runSequence from 'run-sequence';
 import {readdirSync, existsSync, lstatSync} from 'fs';
 import {join} from 'path';
 import {TOOLS_DIR} from '../config';
 
 const TASKS_PATH = join(TOOLS_DIR, 'tasks');
 
-// NOTE: Remove if no issues with runSequence function below.
-// export function loadTasks(): void {
-//   scanDir(TASKS_PATH, (taskname) => registerTask(taskname));
-// }
-
-export function task(taskname: string, option?: string) {
-  util.log('Loading task', chalk.yellow(taskname, option || ''));
-  return require(join('..', 'tasks', taskname))(gulp, gulpLoadPlugins(), option);
+export function loadTasks(): void {
+  scanDir(TASKS_PATH, (taskname) => registerTask(taskname));
 }
 
-export function runSequence(...sequence: any[]) {
-  let tasks = [];
-  let _sequence = sequence.slice(0);
-  sequence.pop();
-
-  scanDir(TASKS_PATH, taskname => tasks.push(taskname));
-
-  sequence.forEach(task => {
-    if (tasks.indexOf(task) > -1) { registerTask(task); }
-  });
-
-  return _runSequence(..._sequence);
+export function task(taskname: string, option?: string) {
+  return (done) => {
+    util.log('Loading task', chalk.yellow(taskname, option || ''));
+    return require(join('..', 'tasks', taskname))(gulp, gulpLoadPlugins(), option)(done);
+  };
 }
 
 // ----------


### PR DESCRIPTION
According to pull request 312, ludohenin created a "new" runSequence method for group tasks in order to load the proper files before we run the task.
I think its unnecessary, and it is better to load everything, but just using a cb.
When the task runs every subtask will load itself.. gulp invoking the cb => we require the file..
it is also not possible to run specific tasks right now like: gulp build.index, and "clean" tasks also pre-loaded, this change will fix that.