### PR TITLE
fixed readme to refer to config.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ If you want to use your custom libraries:
 
 ```bash
 npm install my-library --save
-vim tools/config.js
+vim tools/config.ts
 ```
 Add reference to the installed library in `NPM_DEPENDENCIES`:
 


### PR DESCRIPTION
There is no `config.js` available. Fixed readme to refer to `config.ts`