### PR TITLE
Exclude IDE generated files (.js and .js.map)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ lib
 test
 tools/typings/tsd
 tmp
+
+# Transpiled files
+gulpfile.js*
+app/**/*.js
+app/**/*.js.map
+tools/**/*.js
+tools/**/*.js.map


### PR DESCRIPTION
When using an IDE like Webstorm/IntelliJ, TypeScript files are compiled to .js and .js.map files in the same folder alongside the .ts files (by default).

Would using 'outDir' in 'tsconfig.json' be better?