### PR TITLE
'outDir' added to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "noLib": false,
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
-        "sourceMap": true
+        "sourceMap": true,
+        "outDir": "dev/ts_compiled"
     },
     "exclude": [
         "node_modules"


### PR DESCRIPTION
Specifying location for compiled TypeScript .js and .js.map files to go to keep Git clean.