### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,13 +196,13 @@ tsd install gulp-sass --save
 
 ```ts
 import {join} from 'path';
-import {APP_SRC} from '../config';
+import {APP_SRC, APP_DEST} from '../config';
 
 export = function buildSassDev(gulp, plugins, option) {
   return function () {
     return gulp.src(join(APP_SRC, '**', '*.scss'))
       .pipe(plugins.sass().on('error', plugins.sass.logError))
-      .pipe(gulp.dest(APP_SRC));
+      .pipe(gulp.dest(APP_DEST));
   };
 }
 ```


### PR DESCRIPTION
Fix to write compiled CSS file to application destination folder and the same as the SCSS file. Generally only SCSS files should be kept in VCS.