### PR TITLE
enabling docs build

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -9,6 +9,8 @@ gulp.task('clean.test',  task('clean', 'test'));
 gulp.task('clean.tmp',   task('clean', 'tmp'));
 
 gulp.task('check.versions', task('check.versions'));
+gulp.task('build.docs', task('build.docs'));
+gulp.task('serve.docs', task('serve.docs'));
 
 // --------------
 // Postinstall.
@@ -73,7 +75,7 @@ gulp.task('serve', done =>
 // --------------
 // Docs
 // Disabled until https://github.com/sebastian-lenz/typedoc/issues/162 gets resolved
-// gulp.task('docs', done =>
-//   runSequence('build.docs',
-//               'serve.docs',
-//               done));
+gulp.task('docs', done =>
+  runSequence('build.docs',
+              'serve.docs',
+              done));

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "gulp-template": "^3.0.0",
     "gulp-tslint": "^3.3.0",
     "gulp-tslint-stylish": "^1.0.4",
+    "gulp-typedoc": "^1.2.1",
     "gulp-typescript": "~2.8.2",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.7",


### PR DESCRIPTION
after adding gulp-typedoc we can now build docs