### PR TITLE
fix: allow to name bootstrap file differently than main.ts

### DIFF
--- a/tools/config.ts
+++ b/tools/config.ts
@@ -88,11 +88,11 @@ export const PROD_DEPENDENCIES = PROD_NPM_DEPENDENCIES.concat(APP_ASSETS);
 const SYSTEM_CONFIG_DEV = {
   defaultJSExtensions: true,
   paths: {
-    'main': `${APP_ROOT}main`,
     'hot_loader_main': `${APP_ROOT}hot_loader_main`,
     '*': `${APP_BASE}node_modules/*`
   }
 };
+SYSTEM_CONFIG_DEV.paths[BOOTSTRAP_MODULE] = `${APP_ROOT}${BOOTSTRAP_MODULE}`;
 
 export const SYSTEM_CONFIG = SYSTEM_CONFIG_DEV;
 

--- a/tools/tasks/build.bundles.ts
+++ b/tools/tasks/build.bundles.ts
@@ -2,6 +2,7 @@ import * as merge from 'merge-stream';
 import {join} from 'path';
 import * as browserify from 'browserify';
 import {
+  BOOTSTRAP_MODULE,
   PROD_DEPENDENCIES,
   JS_PROD_SHIMS_BUNDLE,
   JS_PROD_APP_BUNDLE,
@@ -34,7 +35,7 @@ export = function bundles(gulp, plugins) {
     }
 
     function bundleApp() {
-      return browserify(join(TMP_DIR, 'main'))
+      return browserify(join(TMP_DIR, BOOTSTRAP_MODULE))
         .bundle()
         .pipe(require('vinyl-source-stream')(JS_PROD_APP_BUNDLE))
         .pipe(require('vinyl-buffer')())

--- a/tools/tasks/build.test.ts
+++ b/tools/tasks/build.test.ts
@@ -1,5 +1,5 @@
 import {join} from 'path';
-import {BOOTSTRAP_MODULE APP_SRC, TEST_DEST} from '../config';
+import {BOOTSTRAP_MODULE, APP_SRC, TEST_DEST} from '../config';
 import {tsProjectFn} from '../utils';
 
 export = function buildTest(gulp, plugins) {

--- a/tools/tasks/build.test.ts
+++ b/tools/tasks/build.test.ts
@@ -1,5 +1,5 @@
 import {join} from 'path';
-import {APP_SRC, TEST_DEST} from '../config';
+import {BOOTSTRAP_MODULE APP_SRC, TEST_DEST} from '../config';
 import {tsProjectFn} from '../utils';
 
 export = function buildTest(gulp, plugins) {
@@ -7,7 +7,7 @@ export = function buildTest(gulp, plugins) {
     let tsProject = tsProjectFn(plugins);
     let src = [
                 join(APP_SRC, '**/*.ts'),
-                '!' + join(APP_SRC, 'main.ts')
+                '!' + join(APP_SRC, `${BOOTSTRAP_MODULE}.ts`)
               ];
 
     let result = gulp.src(src)


### PR DESCRIPTION
Hi,

I just migrated a simple demo project of mine to use this angular2-seed project. I had some trouble, though, because my startup file was named `bootstrap.ts` rather than `main.ts`.

By looking at the `config.ts` I found there's a variable `BOOTSTRAP_MODULE`. I changed it like this:

```javascript
export const BOOTSTRAP_MODULE     = ENABLE_HOT_LOADING ? 'hot_loader_main' : 'bootstrap';
```
..but it didn't work. After digging a bit in the configuration, I found that the reason is `main` being hardcoded in a couple of places. This PR fixes this. Obviously this shouldn't be a big deal as ppl could only rename their bootstrap file and it's done :smile:.

The only thing I don't really like is that readability of the `SYSTEM_CONFIG_DEV` in `config.ts` suffers a bit. Not sure if there's a better option.. :smile: 