### PR TITLE
Fix test compilation inconsistency

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -26,6 +26,7 @@ gulp.task('build.dev', done =>
               'tslint',
               'build.assets.dev',
               'build.js.dev',
+              'build.e2e_test',
               'build.index.dev',
               done));
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,7 +27,7 @@ module.exports = function(config) {
 
       { pattern: 'node_modules/angular2/**/*.js', included: false, watched: false },
       { pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false },
-      { pattern: 'test/**/*.js', included: false, watched: true },
+      { pattern: 'dist/test/spec/**/*.js', included: false, watched: true },
       { pattern: 'node_modules/systemjs/dist/system-polyfills.js', included: false, watched: false }, // PhantomJS2 (and possibly others) might require it
 
       'test-main.js'

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gulp-watch": "^4.2.4",
     "jasmine-core": "~2.3.4",
     "jasmine-spec-reporter": "^2.4.0",
-    "karma": "~0.13.15",
+    "karma": "~0.13.21",
     "karma-chrome-launcher": "~0.2.0",
     "karma-ie-launcher": "^0.2.0",
     "karma-jasmine": "~0.3.6",

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -2,7 +2,7 @@ exports.config = {
     baseUrl: 'http://localhost:5555',
 
     specs: [
-        'dist/dev/**/*.e2e.js'
+        'dist/test/e2e/**/*.e2e.js'
     ],
     exclude: [],
 

--- a/src/about/components/about.e2e.ts
+++ b/src/about/components/about.e2e.ts
@@ -1,7 +1,7 @@
 describe('About', function() {
 
   beforeEach(function() {
-    browser.get('#/about');
+    browser.get('about');
   });
 
   it('should have an input', function() {

--- a/tools/config.ts
+++ b/tools/config.ts
@@ -26,11 +26,13 @@ export const BOOTSTRAP_MODULE     = ENABLE_HOT_LOADING ? 'hot_loader_main' : 'ma
 export const APP_TITLE            = 'My Angular2 App';
 
 export const APP_SRC              = 'src';
+export const TEST_SRC             = 'src';
 export const ASSETS_SRC           = `${APP_SRC}/assets`;
 
 export const TOOLS_DIR            = 'tools';
 export const TMP_DIR              = 'tmp';
-export const TEST_DEST            = 'test';
+export const TEST_SPEC_DEST       = 'dist/test/spec';
+export const TEST_E2E_DEST        = 'dist/test/e2e';
 export const DOCS_DEST            = 'docs';
 export const APP_DEST             = `dist/${ENV}`;
 export const CSS_DEST             = `${APP_DEST}/css`;

--- a/tools/tasks/build.docs.ts
+++ b/tools/tasks/build.docs.ts
@@ -1,5 +1,5 @@
 import {join} from 'path';
-import {APP_SRC, APP_TITLE, DOCS_DEST} from '../config';
+import {APP_SRC, TEST_SRC, APP_TITLE, DOCS_DEST} from '../config';
 
 export = function buildDocs(gulp, plugins, option) {
   return function() {
@@ -7,8 +7,8 @@ export = function buildDocs(gulp, plugins, option) {
     let src = [
       'typings/main.d.ts',
       join(APP_SRC, '**/*.ts'),
-      '!' + join(APP_SRC, '**/*.spec.ts'),
-      '!' + join(APP_SRC, '**/*.e2e.ts')
+      '!' + join(TEST_SRC, '**/*.spec.ts'),
+      '!' + join(TEST_SRC, '**/*.e2e.ts')
     ];
 
     return gulp.src(src)

--- a/tools/tasks/build.e2e_test.ts
+++ b/tools/tasks/build.e2e_test.ts
@@ -1,16 +1,16 @@
 import {join} from 'path';
-import {APP_SRC, TEST_SRC, APP_DEST} from '../config';
+import {APP_SRC, TEST_SRC, TEST_E2E_DEST} from '../config';
 import {templateLocals, tsProjectFn} from '../utils';
 
-export = function buildJSDev(gulp, plugins) {
+export = function buildE2eTest(gulp, plugins) {
   let tsProject = tsProjectFn(plugins);
 
   return function () {
     let src = [
       'typings/browser.d.ts',
       join(APP_SRC, '**/*.ts'),
-      '!' + join(TEST_SRC, '**/*.spec.ts'),
-      '!' + join(TEST_SRC, '**/*.e2e.ts')
+      join(TEST_SRC, '**/*.e2e.ts'),
+      '!' + join(TEST_SRC, '**/*.spec.ts')
     ];
     let result = gulp.src(src)
       .pipe(plugins.plumber())
@@ -20,6 +20,6 @@ export = function buildJSDev(gulp, plugins) {
     return result.js
       .pipe(plugins.sourcemaps.write())
       .pipe(plugins.template(templateLocals()))
-      .pipe(gulp.dest(APP_DEST));
+      .pipe(gulp.dest(TEST_E2E_DEST));
   };
 };

--- a/tools/tasks/build.js.prod.ts
+++ b/tools/tasks/build.js.prod.ts
@@ -1,5 +1,5 @@
 import {join} from 'path';
-import {APP_SRC, TMP_DIR} from '../config';
+import {APP_SRC, TEST_SRC, TMP_DIR} from '../config';
 import {templateLocals, tsProjectFn} from '../utils';
 
 export = function buildJSProd(gulp, plugins) {
@@ -8,8 +8,8 @@ export = function buildJSProd(gulp, plugins) {
     let src = [
       'typings/browser.d.ts',
       join(APP_SRC, '**/*.ts'),
-      '!' + join(APP_SRC, '**/*.e2e.ts'),
-      '!' + join(APP_SRC, '**/*.spec.ts')
+      '!' + join(TEST_SRC, '**/*.spec.ts'),
+      '!' + join(TEST_SRC, '**/*.e2e.ts')
     ];
 
     let result = gulp.src(src)

--- a/tools/tasks/build.test.ts
+++ b/tools/tasks/build.test.ts
@@ -1,5 +1,5 @@
 import {join} from 'path';
-import {BOOTSTRAP_MODULE, APP_SRC, TEST_DEST} from '../config';
+import {BOOTSTRAP_MODULE, APP_SRC, TEST_SRC, TEST_SPEC_DEST} from '../config';
 import {tsProjectFn} from '../utils';
 
 export = function buildTest(gulp, plugins) {
@@ -8,7 +8,7 @@ export = function buildTest(gulp, plugins) {
     let src = [
       'typings/browser.d.ts',
       join(APP_SRC, '**/*.ts'),
-      '!' + join(APP_SRC, '**/*.e2e.ts'),
+      '!' + join(TEST_SRC, '**/*.e2e.ts'),
       '!' + join(APP_SRC, `${BOOTSTRAP_MODULE}.ts`)
     ];
     let result = gulp.src(src)
@@ -17,6 +17,6 @@ export = function buildTest(gulp, plugins) {
       .pipe(plugins.typescript(tsProject));
 
     return result.js
-      .pipe(gulp.dest(TEST_DEST));
+      .pipe(gulp.dest(TEST_SPEC_DEST));
   };
 };

--- a/tools/tasks/clean.ts
+++ b/tools/tasks/clean.ts
@@ -2,7 +2,7 @@ import * as async from 'async';
 import * as util from 'gulp-util';
 import * as chalk from 'chalk';
 import * as del from 'del';
-import {APP_DEST, TEST_DEST, TMP_DIR} from '../config';
+import {APP_DEST, TEST_SPEC_DEST, TEST_E2E_DEST, TMP_DIR} from '../config';
 
 export = function clean(gulp, plugins, option) {
   return function (done) {
@@ -32,7 +32,7 @@ function cleanDist(done) {
   });
 }
 function cleanTest(done) {
-  del(TEST_DEST).then((paths) => {
+  del([TEST_SPEC_DEST, TEST_E2E_DEST]).then((paths) => {
     util.log('Deleted', chalk.yellow(paths && paths.join(', ') || '-'));
     done();
   });


### PR DESCRIPTION
Fixes issue #447 

- Unit tests get compiled to `/dist/test/spec`
- E2e tests get compiled to `/dist/test/e2e`
- Added `TEST_SRC` constant to `config.js`. By default it points to `src`, but allows the possibility to make it point to `test` (thus keeping app source and test source in different folders).