### PR TITLE
refactor(Component): URLs relative to component

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "gulp-cssnano": "^2.0.0",
     "gulp-filter": "^2.0.2",
     "gulp-inject": "^1.3.1",
-    "gulp-inline-ng2-template": "^0.0.7",
+    "gulp-inline-ng2-template": "^0.0.11",
     "gulp-load-plugins": "^0.10.0",
     "gulp-plumber": "~1.0.1",
     "gulp-shell": "~0.4.3",

--- a/src/about/components/about.ts
+++ b/src/about/components/about.ts
@@ -5,7 +5,8 @@ import {NameList} from '../../shared/services/name_list';
 
 @Component({
   selector: 'about',
-  templateUrl: './about/components/about.html',
+  moduleId: module.id,
+  templateUrl: './about.html',
   directives: [FORM_DIRECTIVES, CORE_DIRECTIVES]
 })
 export class AboutCmp {

--- a/src/app/components/app.ts
+++ b/src/app/components/app.ts
@@ -11,8 +11,9 @@ import {NameList} from '../../shared/services/name_list';
 @Component({
   selector: 'app',
   viewProviders: [NameList],
-  templateUrl: './app/components/app.html',
-  styleUrls: ['./app/components/app.css'],
+  moduleId: module.id,
+  templateUrl: './app.html',
+  styleUrls: ['./app.css'],
   encapsulation: ViewEncapsulation.None,
   directives: [ROUTER_DIRECTIVES]
 })

--- a/src/home/components/home.ts
+++ b/src/home/components/home.ts
@@ -2,7 +2,8 @@ import {Component} from 'angular2/core';
 
 @Component({
   selector: 'home',
-  templateUrl: './home/components/home.html',
-  styleUrls: ['./home/components/home.css']
+  moduleId: module.id,
+  templateUrl: './home.html',
+  styleUrls: ['./home.css']
 })
 export class HomeCmp {}

--- a/tools/tasks/build.js.prod.ts
+++ b/tools/tasks/build.js.prod.ts
@@ -14,7 +14,7 @@ export = function buildJSProd(gulp, plugins) {
 
     let result = gulp.src(src)
       .pipe(plugins.plumber())
-      .pipe(plugins.inlineNg2Template({ base: TMP_DIR }))
+      .pipe(plugins.inlineNg2Template({ base: TMP_DIR , useRelativePaths: true }))
       .pipe(plugins.typescript(tsProject));
 
     return result.js

--- a/tools/tasks/build.test.ts
+++ b/tools/tasks/build.test.ts
@@ -13,7 +13,7 @@ export = function buildTest(gulp, plugins) {
     ];
     let result = gulp.src(src)
       .pipe(plugins.plumber())
-      .pipe(plugins.inlineNg2Template({ base: APP_SRC }))
+      .pipe(plugins.inlineNg2Template({ base: APP_SRC, useRelativePaths: true }))
       .pipe(plugins.typescript(tsProject));
 
     return result.js


### PR DESCRIPTION
- minimum inline-ng2-template plugin minimum version to 0.0.11
- Relative URLs for all components
- inline-ng2-template set to use comp. relative path

resolves #485 

Will squash after review