### PR TITLE
Patch 2

### DIFF
--- a/tools/config.ts
+++ b/tools/config.ts
@@ -110,9 +110,8 @@ export const SYSTEM_CONFIG = SYSTEM_CONFIG_DEV;
 export const SYSTEM_BUILDER_CONFIG = {
   defaultJSExtensions: true,
   paths: {
-    '*': `${TMP_DIR}/*`,
-    'angular2/*': 'node_modules/angular2/*',
-    'rxjs/*': 'node_modules/rxjs/*'
+    'tmp/*': 'tmp/*',
+    '*': `node_modules/*`
   }
 };
 

--- a/tools/tasks/build.bundles.app.ts
+++ b/tools/tasks/build.bundles.app.ts
@@ -5,6 +5,7 @@ import {
   JS_PROD_APP_BUNDLE,
   JS_DEST,
   SYSTEM_BUILDER_CONFIG,
+  TMP_DIR
 } from '../config';
 
 const BUNDLER_OPTIONS = {
@@ -17,7 +18,9 @@ export = function bundles(gulp, plugins) {
   return function (done) {
     let builder = new Builder(SYSTEM_BUILDER_CONFIG);
     builder
-      .buildStatic(BOOTSTRAP_MODULE, join(JS_DEST, JS_PROD_APP_BUNDLE), BUNDLER_OPTIONS)
+      .buildStatic(join(TMP_DIR, BOOTSTRAP_MODULE),
+                   join(JS_DEST, JS_PROD_APP_BUNDLE),
+                   BUNDLER_OPTIONS)
       .then(() => done());
   };
 };


### PR DESCRIPTION
No need to declare NPM libs in the config anymore as long as they follow the convention `node_modules/lib_name/lib_name.js`