### PR TITLE
Cleanup: Cleanup npm from npm

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -13,13 +13,6 @@ gulp.task('build.docs', task('build.docs'));
 gulp.task('serve.docs', task('serve.docs'));
 
 // --------------
-// Postinstall.
-gulp.task('postinstall', done =>
-  runSequence('clean',
-              'npm',
-              done));
-
-// --------------
 // Build dev.
 gulp.task('build.dev', done =>
   runSequence('clean.dist',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gulp": "gulp",
     "karma": "karma",
     "karma.start": "karma start",
-    "postinstall": "typings install && gulp check.versions && gulp postinstall",
+    "postinstall": "typings install && gulp check.versions && npm prune",
     "reinstall": "rimraf node_modules && npm cache clean && npm install",
     "start": "gulp serve --env dev",
     "serve.dev": "gulp serve --env dev",

--- a/tools/tasks/npm.ts
+++ b/tools/tasks/npm.ts
@@ -1,5 +1,0 @@
-export = function npm(gulp, plugins) {
-  return plugins.shell.task([
-    'npm prune'
-  ]);
-};


### PR DESCRIPTION
During postinstall we start gulp in order to start npm and run `npm prune`

We also clean the dist folder, which is completely irrelevant during install.

I suggest this to change so that the postinstall step directly prunes unused npm
packages.

Since we remove the extra gulp step, it can also shave 2-3 seconds off of a CI
build step.