### PR TITLE
(performance) Faster loading of tasks (skip unused)

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -3,13 +3,12 @@ import {runSequence, task} from './tools/utils';
 
 // --------------
 // Clean (override).
-gulp.task('clean',       task('clean', 'all'));
-gulp.task('clean.dev',   task('clean', 'dev'));
-gulp.task('clean.prod',  task('clean', 'prod'));
-
-gulp.task('check.versions', task('check.versions'));
-gulp.task('build.docs', task('build.docs'));
-gulp.task('serve.docs', task('serve.docs'));
+gulp.task('clean',          () => { task('clean', 'all'  ); });
+gulp.task('clean.dev',      () => { task('clean', 'dev' ); });
+gulp.task('clean.prod',     () => { task('clean', 'prod' ); });
+gulp.task('check.versions', () => { task('check.versions'); });
+gulp.task('build.docs',     () => { task('build.docs'    ); });
+gulp.task('serve.docs',     () => { task('serve.docs'    ); });
 
 // --------------
 // Build dev.


### PR DESCRIPTION
This has annoyed me forever. On my machine, calling the custom "task()" method takes roughly half a
second.

Depending on which gulp task you execute, there is no reason to load these tasks in the top of
the gulpfile. I wrap them in a function, which hides the underlying true problem.

The real problem is of course that the loading of tasks take a long time, and hides unused tasks so that we never delete them.

But that will be a separate problem requiring a bigger fix.