### PR TITLE
Pass async done function to clean tasks

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -3,12 +3,12 @@ import {runSequence, task} from './tools/utils';
 
 // --------------
 // Clean (override).
-gulp.task('clean',          () => { task('clean', 'all'  ); });
-gulp.task('clean.dev',      () => { task('clean', 'dev' ); });
-gulp.task('clean.prod',     () => { task('clean', 'prod' ); });
-gulp.task('check.versions', () => { task('check.versions'); });
-gulp.task('build.docs',     () => { task('build.docs'    ); });
-gulp.task('serve.docs',     () => { task('serve.docs'    ); });
+gulp.task('clean',          done => { task('clean', 'all'  )(done); });
+gulp.task('clean.dev',      done => { task('clean', 'dev'  )(done); });
+gulp.task('clean.prod',     done => { task('clean', 'prod' )(done); });
+gulp.task('check.versions', () =>   { task('check.versions');       });
+gulp.task('build.docs',     () =>   { task('build.docs'    );       });
+gulp.task('serve.docs',     () =>   { task('serve.docs'    );       });
 
 // --------------
 // Build dev.


### PR DESCRIPTION
Without passing this function, the clean task would exit before the system was able to delete the requested files.

Fixes #516 gulp clean does not erase files