### PR TITLE
Updated trailing-comma rule tslint.json

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -16,7 +16,6 @@
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
-    "no-trailing-comma": true,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
     "no-unused-variable": true,
@@ -30,6 +29,7 @@
     ],
     "quotemark": [true, "single"],
     "semicolon": true,
+    "trailing-comma": true,
     "triple-equals": true,
     "variable-name": false,
 


### PR DESCRIPTION
"no-trailing-comma" has been replaced with "trailing-comma" since v3.0.0.dev.1

[breaking change notice](https://github.com/palantir/tslint/blob/master/CHANGELOG.md#v300-dev1)

package.json in master is currently at 3.3.0