### PR TITLE
updated gulp-typescript from 2.8.0 to 2.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "gulp-tslint": "^4.3.2",
     "gulp-tslint-stylish": "^1.0.4",
     "gulp-typedoc": "^1.2.1",
-    "gulp-typescript": "~2.8.2",
+    "gulp-typescript": "~2.10.0",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.2.4",


### PR DESCRIPTION
I haven't seen this error happening on angular2-seed  since it is not using RouterOutlet.
However, I saw the following error without this upgrade on my own project
and I have spent few hours to find this solution. This upgrade would be useful for others.

"Uncaught Uncaught Uncaught ReferenceError: RouterOutlet is not defined"

Typescript:
```
import {Directive, Attribute, ElementRef, DynamicComponentLoader} from 'angular2/core';
import {Router, RouterOutlet, ComponentInstruction} from 'angular2/router';
import {AuthenticationToken} from '../services/security/tokens';
import {CetRouteData} from '../services/cetRouteData';
```

JS generated before upgrade: 
```
var core_1 = require('angular2/core');
var tokens_1 = require('../services/security/tokens');
var cetRouteData_1 = require('../services/cetRouteData');
```
Js generated after upgrade:
```
var core_1 = require('angular2/core');
var router_1 = require('angular2/router');
var tokens_1 = require('../services/security/tokens');
var cetRouteData_1 = require('../services/cetRouteData');
```


