### PR TITLE
chore(tools): Update dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "gulp-sourcemaps": "~1.5.2",
     "gulp-template": "^3.0.0",
     "gulp-tslint": "^4.3.2",
-    "gulp-tslint-stylish": "^1.0.4",
+    "gulp-tslint-stylish": "^1.1.1",
     "gulp-typedoc": "^1.2.1",
     "gulp-typescript": "~2.12.0",
     "gulp-uglify": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "serve-static": "^1.10.2",
     "slash": "~1.0.0",
     "stream-series": "^0.1.1",
-    "systemjs-builder": "^0.15.7",
+    "systemjs-builder": "^0.15.10",
     "tiny-lr": "^0.2.1",
     "traceur": "^0.0.91",
     "ts-node": "^0.5.5",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "remap-istanbul": "^0.5.1",
     "rimraf": "^2.5.2",
     "run-sequence": "^1.1.0",
-    "semver": "^5.0.3",
+    "semver": "^5.1.0",
     "serve-static": "^1.10.2",
     "slash": "~1.0.0",
     "stream-series": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "systemjs-builder": "^0.15.7",
     "tiny-lr": "^0.2.1",
     "traceur": "^0.0.91",
-    "ts-node": "^0.5.4",
+    "ts-node": "^0.5.5",
     "tslint": "^3.5.0",
     "typedoc": "^0.3.12",
     "typescript": "~1.8.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gulp-load-plugins": "^0.10.0",
     "gulp-plumber": "~1.0.1",
     "gulp-shell": "~0.4.3",
-    "gulp-sourcemaps": "~1.5.2",
+    "gulp-sourcemaps": "~1.6.0",
     "gulp-template": "^3.0.0",
     "gulp-tslint": "^4.3.2",
     "gulp-tslint-stylish": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "rimraf": "^2.5.2",
     "run-sequence": "^1.1.0",
     "semver": "^5.0.3",
-    "serve-static": "^1.9.2",
+    "serve-static": "^1.10.2",
     "slash": "~1.0.0",
     "stream-series": "^0.1.1",
     "systemjs-builder": "^0.15.7",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "tiny-lr": "^0.2.1",
     "traceur": "^0.0.91",
     "ts-node": "^0.5.4",
-    "tslint": "^3.3.0",
+    "tslint": "^3.5.0",
     "typedoc": "^0.3.12",
     "typescript": "~1.8.0",
     "typings": "^0.6.8",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "tslint": "^3.3.0",
     "typedoc": "^0.3.12",
     "typescript": "~1.8.0",
-    "typings": "^0.6.2",
+    "typings": "^0.6.8",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "yargs": "^3.32.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "gulp-tslint": "^4.3.2",
     "gulp-tslint-stylish": "^1.0.4",
     "gulp-typedoc": "^1.2.1",
-    "gulp-typescript": "~2.10.0",
+    "gulp-typescript": "~2.12.0",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.2.4",


### PR DESCRIPTION
**Patch version**
- Update Typings from 0.6.2 to 0.6.8
- Update ts-node from 0.5.4 to 0.5.5
- Update systemjs-builder from 0.15.7 to 0.15.10

**Minor Version**
- Update tslint from 3.3.0 to 3.5.0
- Update gulp-typescript from 2.10.0 to 2.12.0
- Update gulp-tslint-stylish from 1.0.4 to 1.1.1
- Update serve-static from 1.9.2 to 1.10.2
- Update semver from 5.0.3 to 5.1.0
- Update gulp-sourcemaps from 1.5.2 to 1.6.0

> Verified on OSX 10.11.3, Ubuntu 14.04.3 & Windows 10

resolves #544 