### PR TITLE
made available for a single file test for karma

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,6 +2,8 @@
 // Generated on Wed Jul 15 2015 09:44:02 GMT+0200 (Romance Daylight Time)
 'use strict';
 
+var argv = require('yargs').argv;
+
 module.exports = function(config) {
   config.set({
 
@@ -47,7 +49,6 @@ module.exports = function(config) {
     preprocessors: {
       'dist/**/!(*spec).js': ['coverage']
     },
-
 
     // test results reporter to use
     // possible values: 'dots', 'progress'
@@ -98,7 +99,12 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false
+    singleRun: false, 
+
+    // Passing command line arguments to tests
+    client: {
+      files: argv.files
+    }
   });
 
   if (process.env.APPVEYOR) {

--- a/test-main.js
+++ b/test-main.js
@@ -62,7 +62,11 @@ Promise.all([
 });
 
 function onlySpecFiles(path) {
-  return /[\.|_]spec\.js$/.test(path);
+  // check for individual files, if not given, always matcches to all
+  var patternMatched = __karma__.config.files ?
+    path.match(new RegExp(__karma__.config.files)) : true;
+
+  return patternMatched && /[\.|_]spec\.js$/.test(path);
 }
 
 // Normalize paths to module names.


### PR DESCRIPTION
This change makes available for a single file test.

While development, we run a single file unit test over and over again. It would be useful to have a single file test.

This is how it runs. 
For a single file test, just add `--files=FILENAME`. The output would be like thisl
```
angular2-seed (master)$ gulp test --files=app
  App component
    ✔ should work
WARN: 'DEPRECATION WARNING: 'dequeueTask' is no longer supported and will be removed in next major release. Use removeTask/removeRepeatingTask/removeMicroTask'
01 03 2016 08:24:56.633:WARN [web-server]: 404: /assets/svg/more.svg
Chrome 48.0.2564 (Mac OS X 10.11.1) WARN: 'DEPRECATION WARNING: 'dequeueTask' is no longer supported and will be removed in next major release. Use removeTask/removeRepeatingTask/removeMicroTask'

Finished in 0.217 secs / 0.35 secs

SUMMARY:
✔ 2 tests completed
```

For a full tests, no change is required.

```
angular2-seed (master)$ gulp test
Chrome 48.0.2564 (Mac OS X 10.11.1) WARN: 'DEPRECATION WARNING: 'enqueueTask' is no longer supported and will be removed in next major release. Use addTask/addRepeatingTask/addMicroTask'
  About component
    ✔ should work
  Home component
    ✔ should work
  NameList Service
    ✔ should return the list of names
01 03 2016 08:25:38.502:WARN [web-server]: 404: /assets/svg/more.svg
  App component
    ✔ should work
WARN: 'DEPRECATION WARNING: 'dequeueTask' is no longer supported and will be removed in next major release. Use removeTask/removeRepeatingTask/removeMicroTask'
01 03 2016 08:25:38.894:WARN [web-server]: 404: /assets/svg/more.svg
Chrome 48.0.2564 (Mac OS X 10.11.1) WARN: 'DEPRECATION WARNING: 'dequeueTask' is no longer supported and will be removed in next major release. Use removeTask/removeRepeatingTask/removeMicroTask'

Finished in 0.525 secs / 0.508 secs

SUMMARY:
✔ 8 tests completed
```
