### PR TITLE
Removed ViewEncapsulation.None (unnecessary)

### DIFF
--- a/src/app/components/app.component.ts
+++ b/src/app/components/app.component.ts
@@ -1,4 +1,4 @@
-import {Component, ViewEncapsulation} from 'angular2/core';
+import {Component} from 'angular2/core';
 import {ROUTER_DIRECTIVES, RouteConfig} from 'angular2/router';
 import {NavbarComponent} from './navbar.component';
 import {ToolbarComponent} from './toolbar.component';
@@ -11,7 +11,6 @@ import {NameListService} from '../../shared/services/name-list.service';
   viewProviders: [NameListService],
   moduleId: module.id,
   templateUrl: './app.component.html',
-  encapsulation: ViewEncapsulation.None,
   directives: [ROUTER_DIRECTIVES, NavbarComponent, ToolbarComponent]
 })
 @RouteConfig([


### PR DESCRIPTION
I wondered what this did and why we have it in the seed project?

ViewEncapsulation.None tells Angular not to use shadow DOM

Does  this make a difference? Did it slow down the code/tests/runtime?

My suggestion is to remove it.

More info http://blog.thoughtram.io/angular/2015/06/29/shadow-dom-strategies-in-angular2.html