### PR TITLE
set noImplicitAny to true and fix errors

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -9,7 +9,7 @@ loadTasks(PROJECT_TASKS_DIR);
 
 // --------------
 // Build dev.
-gulp.task('build.dev', done =>
+gulp.task('build.dev', (done: any) =>
   runSequence('clean.dev',
               'tslint',
               'build.assets.dev',
@@ -19,14 +19,14 @@ gulp.task('build.dev', done =>
 
 // --------------
 // Build dev watch.
-gulp.task('build.dev.watch', done =>
+gulp.task('build.dev.watch', (done: any) =>
   runSequence('build.dev',
               'watch.dev',
               done));
 
 // --------------
 // Build e2e.
-gulp.task('build.e2e', done =>
+gulp.task('build.e2e', (done: any) =>
   runSequence('clean.dev',
               'tslint',
               'build.assets.dev',
@@ -36,7 +36,7 @@ gulp.task('build.e2e', done =>
 
 // --------------
 // Build prod.
-gulp.task('build.prod', done =>
+gulp.task('build.prod', (done: any) =>
   runSequence('clean.prod',
               'tslint',
               'build.assets.prod',
@@ -49,7 +49,7 @@ gulp.task('build.prod', done =>
 
 // --------------
 // Build test.
-gulp.task('build.test', done =>
+gulp.task('build.test', (done: any) =>
   runSequence('clean.dev',
               'tslint',
               'build.assets.dev',
@@ -59,28 +59,28 @@ gulp.task('build.test', done =>
 
 // --------------
 // Build test watch.
-gulp.task('build.test.watch', done =>
+gulp.task('build.test.watch', (done: any) =>
   runSequence('build.test',
               'watch.test',
               done));
 
 // --------------
 // Build tools.
-gulp.task('build.tools', done =>
+gulp.task('build.tools', (done: any) =>
   runSequence('clean.tools',
               'build.js.tools',
               done));
 
 // --------------
 // Docs
-gulp.task('docs', done =>
+gulp.task('docs', (done: any) =>
   runSequence('build.docs',
               'serve.docs',
               done));
 
 // --------------
 // Serve dev
-gulp.task('serve.dev', done =>
+gulp.task('serve.dev', (done: any) =>
   runSequence('build.dev',
               'server.start',
               'watch.dev',
@@ -88,7 +88,7 @@ gulp.task('serve.dev', done =>
 
 // --------------
 // Serve e2e
-gulp.task('serve.e2e', done =>
+gulp.task('serve.e2e', (done: any) =>
   runSequence('build.e2e',
               'server.start',
               'watch.e2e',
@@ -96,7 +96,7 @@ gulp.task('serve.e2e', done =>
 
 // --------------
 // Test.
-gulp.task('test', done =>
+gulp.task('test', (done: any) =>
   runSequence('build.test',
               'karma.start',
               done));

--- a/src/shared/services/name-list.service.spec.ts
+++ b/src/shared/services/name-list.service.spec.ts
@@ -2,7 +2,7 @@ import {NameListService} from './name-list.service';
 
 export function main() {
   describe('NameList Service', () => {
-    let nameListService;
+    let nameListService: NameListService;
 
     beforeEach(() => {
       nameListService = new NameListService;

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -2,12 +2,12 @@ import {join} from 'path';
 import {SeedConfig, normalizeDependencies} from './seed.config';
 
 export class ProjectConfig extends SeedConfig {
-  PROJECT_TASKS_DIR    = join(process.cwd(), this.TOOLS_DIR, 'tasks', 'project');
+  PROJECT_TASKS_DIR = join(process.cwd(), this.TOOLS_DIR, 'tasks', 'project');
 
   constructor() {
     super();
     // this.APP_TITLE = 'Put name of your app here';
-    let additional_deps = [
+    let additional_deps: Array<any> = [
       // {src: 'jquery/dist/jquery.min.js', inject: 'libs'},
       // {src: 'lodash/lodash.min.js', inject: 'libs'},
     ];
@@ -18,7 +18,7 @@ export class ProjectConfig extends SeedConfig {
     this.APP_ASSETS = [
       // {src: `${this.ASSETS_SRC}/css/toastr.min.css`, inject: true},
       // {src: `${this.APP_DEST}/assets/scss/global.css`, inject: true},
-      {src: `${this.ASSETS_SRC}/main.css`, inject: true},
+      { src: `${this.ASSETS_SRC}/main.css`, inject: true },
     ];
 
     this.DEV_DEPENDENCIES = this.DEV_NPM_DEPENDENCIES.concat(this.APP_ASSETS);

--- a/tools/tasks/seed/build.assets.prod.ts
+++ b/tools/tasks/seed/build.assets.prod.ts
@@ -3,9 +3,9 @@ import {join} from 'path';
 import {APP_SRC, APP_DEST, ASSETS_SRC} from '../../config';
 
 // TODO There should be more elegant to prevent empty directories from copying
-let es = require('event-stream');
-var onlyDirs = function (es) {
-  return es.map(function (file, cb) {
+let es: any = require('event-stream');
+var onlyDirs = function (es: any) {
+  return es.map(function (file: any, cb: any) {
     if (file.stat.isFile()) {
       return cb(null, file);
     } else {

--- a/tools/tasks/seed/build.bundles.app.ts
+++ b/tools/tasks/seed/build.bundles.app.ts
@@ -14,7 +14,7 @@ const BUNDLER_OPTIONS = {
   mangle: false
 };
 
-export = done => {
+export = (done: any) => {
   let builder = new Builder(SYSTEM_BUILDER_CONFIG);
   builder
     .buildStatic(join(TMP_DIR, BOOTSTRAP_MODULE),

--- a/tools/tasks/seed/build.index.dev.ts
+++ b/tools/tasks/seed/build.index.dev.ts
@@ -29,7 +29,7 @@ function getInjectablesDependenciesRef(name?: string) {
     .map(mapPath);
 }
 
-function mapPath(dep) {
+function mapPath(dep: any) {
   let envPath = dep.src;
   if (envPath.startsWith(APP_SRC)) {
     envPath = join(APP_DEST, dep.src.replace(APP_SRC, ''));
@@ -38,7 +38,7 @@ function mapPath(dep) {
 }
 
 function transformPath() {
-  return function (filepath) {
+  return function (filepath: string) {
     arguments[0] = join(APP_BASE, filepath) + `?${Date.now()}`;
     return slash(plugins.inject.transform.apply(plugins.inject.transform, arguments));
   };

--- a/tools/tasks/seed/build.index.prod.ts
+++ b/tools/tasks/seed/build.index.prod.ts
@@ -22,11 +22,17 @@ export = () => {
     .pipe(gulp.dest(APP_DEST));
 }
 
-function inject(...files) {
+function inject(...files: any[]) {
     return plugins.inject(gulp.src(files, { read: false }), {
         files,
         transform: transformPath()
-    });
+    }), {
+      transform: function (filepath: string) {
+        let path = normalize(filepath).split(sep);
+        arguments[0] = path.slice(3, path.length).join(sep) + `?${Date.now()}`;
+        return plugins.inject.transform.apply(plugins.inject.transform, arguments);
+      }
+    };
 }
 
 function injectJs() {
@@ -39,7 +45,7 @@ function injectCss() {
 }
 
 function transformPath() {
-    return function(filepath) {
+    return function(filepath:string) {
         let path = normalize(filepath).split(sep);
         arguments[0] = path.slice(3, path.length).join(sep) + `?${Date.now()}`;
         return slash(plugins.inject.transform.apply(plugins.inject.transform, arguments));

--- a/tools/tasks/seed/build.index.prod.ts
+++ b/tools/tasks/seed/build.index.prod.ts
@@ -22,22 +22,15 @@ export = () => {
     .pipe(gulp.dest(APP_DEST));
 }
 
-function inject(...files: any[]) {
+function inject(...files: Array<string>) {
     return plugins.inject(gulp.src(files, { read: false }), {
         files,
         transform: transformPath()
-    }), {
-      transform: function (filepath: string) {
-        let path = normalize(filepath).split(sep);
-        arguments[0] = path.slice(3, path.length).join(sep) + `?${Date.now()}`;
-        return plugins.inject.transform.apply(plugins.inject.transform, arguments);
-      }
-    };
+    });
 }
 
 function injectJs() {
-  return inject(join(JS_DEST, JS_PROD_SHIMS_BUNDLE),
-    join(JS_DEST, JS_PROD_APP_BUNDLE));
+  return inject(join(JS_DEST, JS_PROD_SHIMS_BUNDLE), join(JS_DEST, JS_PROD_APP_BUNDLE));
 }
 
 function injectCss() {
@@ -45,9 +38,9 @@ function injectCss() {
 }
 
 function transformPath() {
-    return function(filepath:string) {
-        let path = normalize(filepath).split(sep);
-        arguments[0] = path.slice(3, path.length).join(sep) + `?${Date.now()}`;
-        return slash(plugins.inject.transform.apply(plugins.inject.transform, arguments));
-    };
+  return function(filepath: string) {
+    let path: Array<string> = normalize(filepath).split(sep);
+    arguments[0] = path.slice(3, path.length).join(sep) + `?${Date.now()}`;
+    return slash(plugins.inject.transform.apply(plugins.inject.transform, arguments));
+  };
 }

--- a/tools/tasks/seed/check.versions.ts
+++ b/tools/tasks/seed/check.versions.ts
@@ -10,7 +10,7 @@ export = () => {
   let semver = require('semver');
 
   exec('npm --version',
-    function (error: string, stdout:string, stderr:string) {
+    function (error: Error, stdout: Buffer, stderr: Buffer) {
       if (error !== null) {
         reportError('npm preinstall error: ' + error + stderr);
       }
@@ -21,7 +21,7 @@ export = () => {
     });
 
   exec('node --version',
-    function (error: string, stdout:string, stderr:string) {
+    function (error: Error, stdout: Buffer, stderr: Buffer) {
       if (error !== null) {
         reportError('npm preinstall error: ' + error + stderr);
       }

--- a/tools/tasks/seed/check.versions.ts
+++ b/tools/tasks/seed/check.versions.ts
@@ -10,7 +10,7 @@ export = () => {
   let semver = require('semver');
 
   exec('npm --version',
-    function (error: Error, stdout: Buffer, stderr: Buffer) {
+    function (error: Error, stdout: NodeBuffer, stderr: NodeBuffer) {
       if (error !== null) {
         reportError('npm preinstall error: ' + error + stderr);
       }
@@ -21,7 +21,7 @@ export = () => {
     });
 
   exec('node --version',
-    function (error: Error, stdout: Buffer, stderr: Buffer) {
+    function (error: Error, stdout: NodeBuffer, stderr: NodeBuffer) {
       if (error !== null) {
         reportError('npm preinstall error: ' + error + stderr);
       }

--- a/tools/tasks/seed/check.versions.ts
+++ b/tools/tasks/seed/check.versions.ts
@@ -10,7 +10,7 @@ export = () => {
   let semver = require('semver');
 
   exec('npm --version',
-    function (error, stdout, stderr) {
+    function (error: string, stdout:string, stderr:string) {
       if (error !== null) {
         reportError('npm preinstall error: ' + error + stderr);
       }
@@ -21,7 +21,7 @@ export = () => {
     });
 
   exec('node --version',
-    function (error, stdout, stderr) {
+    function (error: string, stdout:string, stderr:string) {
       if (error !== null) {
         reportError('npm preinstall error: ' + error + stderr);
       }

--- a/tools/tasks/seed/karma.start.ts
+++ b/tools/tasks/seed/karma.start.ts
@@ -1,7 +1,7 @@
 import * as karma from 'karma';
 import {join} from 'path';
 
-export = done => {
+export = (done: any) => {
   new (<any>karma).Server({
     configFile: join(process.cwd(), 'karma.conf.js'),
     singleRun: true

--- a/tools/utils/seed/code_change_tools.ts
+++ b/tools/utils/seed/code_change_tools.ts
@@ -36,7 +36,7 @@ let listen = () => {
   runServer();
 };
 
-let changed = files => {
+let changed = (files: any) => {
   if (!(files instanceof Array)) {
     files = [files];
   }

--- a/tools/utils/seed/tasks_tools.ts
+++ b/tools/utils/seed/tasks_tools.ts
@@ -15,7 +15,7 @@ function registerTask(taskname: string, path: string): void {
   const TASK = join(path, taskname);
   util.log('Registering task', chalk.yellow(TASK));
 
-  gulp.task(taskname, done => {
+  gulp.task(taskname, (done: any) => {
     const task = require(TASK);
     if (task.length > 0) {
       return task(done);
@@ -37,7 +37,7 @@ function readDir(root: string, cb: (taskname: string) => void) {
 
   walk(root);
 
-  function walk(path) {
+  function walk(path: string) {
     let files = readdirSync(path);
     for (let i = 0; i < files.length; i += 1) {
       let file = files[i];

--- a/tools/utils/seed/tsproject.ts
+++ b/tools/utils/seed/tsproject.ts
@@ -1,7 +1,7 @@
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 const plugins = <any>gulpLoadPlugins();
 
-var _tsProject;
+let _tsProject: any;
 
 export function makeTsProject() {
   if (!_tsProject) {

--- a/tools/utils/seed/watch.ts
+++ b/tools/utils/seed/watch.ts
@@ -4,7 +4,7 @@ import {join} from 'path';
 import {APP_SRC} from '../../config';
 const plugins = <any>gulpLoadPlugins();
 
-export function watch(taskname) {
+export function watch(taskname: string) {
   return () => {
     plugins.watch(join(APP_SRC, '**/*'),
       () => gulp.start(taskname));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "pretty": true,
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitUseStrict": false,
     "noFallthroughCasesInSwitch": true


### PR DESCRIPTION
Set the flag: `noImplicitAny` to `true` in tsconfig.json
See: https://github.com/angular/angular/issues/4924

When you set the flag to `true`, most errors appear in `gulpfile.ts and the settings:
```bash
 Unable to compile TypeScript

gulpfile.ts (12,24): Parameter 'done' implicitly has an 'any' type. (7006)
gulpfile.ts (22,30): Parameter 'done' implicitly has an 'any' type. (7006)
gulpfile.ts (29,24): Parameter 'done' implicitly has an 'any' type. (7006)
gulpfile.ts (39,25): Parameter 'done' implicitly has an 'any' type. (7006)
gulpfile.ts (52,25): Parameter 'done' implicitly has an 'any' type. (7006)
gulpfile.ts (62,31): Parameter 'done' implicitly has an 'any' type. (7006)
gulpfile.ts (69,26): Parameter 'done' implicitly has an 'any' type. (7006)
gulpfile.ts (76,19): Parameter 'done' implicitly has an 'any' type. (7006)
gulpfile.ts (83,24): Parameter 'done' implicitly has an 'any' type. (7006)
gulpfile.ts (91,24): Parameter 'done' implicitly has an 'any' type. (7006)
gulpfile.ts (99,19): Parameter 'done' implicitly has an 'any' type. (7006)
tools/utils/seed/code_change_tools.ts (39,15): Parameter 'files' implicitly has an 'any' type. (7006)
tools/utils/seed/tasks_tools.ts (18,23): Parameter 'done' implicitly has an 'any' type. (7006)
tools/utils/seed/tasks_tools.ts (40,17): Parameter 'path' implicitly has an 'any' type. (7006)
tools/utils/seed/tsproject.ts (4,5): Variable '_tsProject' implicitly has an 'any' type. (7005)
tools/utils/seed/watch.ts (7,23): Parameter 'taskname' implicitly has an 'any' type. (7006)
```

Tried to fix al errors with the correct type. Unfortunately my knowledge of Typescript and Gulp isn't good enough to know all the correct types. 
So wherever `any` is used. It should be double checked what the proper type is.

Note:
 using `done: Function` in the gulpfile.ts results in:
`Type 'Function' is not assignable to type 'TaskCallback'. (2345)
gulpfile.ts (65,15): Argument of type 'Function' is not assignable to parameter of type 'string | string[] | TaskCallback'.`

Should the type in that case be TaskCallback? -> Which cannot be found/recognized

 