### PR TITLE
Fixes failing app component e2e test

### DIFF
--- a/src/app/components/app.component.e2e.ts
+++ b/src/app/components/app.component.e2e.ts
@@ -5,7 +5,7 @@ describe('App', () => {
   });
 
   it('should have a title', () => {
-      expect(browser.getTitle()).toEqual('Angular 2 Seed');
+      expect(browser.getTitle()).toEqual('My Angular2 App');
   });
 
   it('should have <nav>', () => {

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -6,7 +6,7 @@ export class ProjectConfig extends SeedConfig {
 
   constructor() {
     super();
-    this.APP_TITLE = 'Put name of your app here';
+    // this.APP_TITLE = 'Put name of your app here';
     let additional_deps = [
       // {src: 'jquery/dist/jquery.min.js', inject: 'libs'},
       // {src: 'lodash/lodash.min.js', inject: 'libs'},


### PR DESCRIPTION
Good morning,

the assert `'should have a title'` in `app.component.e2e.ts` currently fails on the latest master.

**Reason:** The assert expects the title to be `'Angular 2 Seed'`, but is actually `'Put name of your app here'` (which was introduced by the commit 598efd5f669def1a9f573007a958912117275d9d)

**Possible solutions:**

_A)_
- Fix the assert in `app.component.e2e.ts` to expect `'My Angular 2 App'` 
- Comment out the `this.APP_TITLE` in `project.config.ts`

_Pro:_ 
- Set expectations in the e2e test to the baseline configuration of the seed
- Commenting out the override in `project.config.ts` to still have the example of how to change the tile, yet not alter the baseline seed configuration

_Con:_
- The override of the project specific app title would be reverted

_B)_
- Fix the assert in `app.component.e2e.ts` to expect `'Put name of your app here'` 

_Pro:_
- Assert would be fixed to expected the overriden app title

_Con:_
- Expectation would deviate from baseline seed configuration

**Proposed soultion:**

The attached commit is target at solution _A)_.

Greetings

Christian