### PR TITLE
fix(build): BrowserSync Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "async": "^1.4.2",
     "autoprefixer": "^6.3.3",
-    "browser-sync": "^2.11.1",
+    "browser-sync": "~2.10.1",
     "chalk": "^1.1.1",
     "colorguard": "^1.0.1",
     "connect": "^3.4.1",

--- a/tools/utils/seed/code_change_tools.ts
+++ b/tools/utils/seed/code_change_tools.ts
@@ -44,7 +44,7 @@ let changed = (files: any) => {
   //   ng2HotLoader.onChange(files);
   // } else {
   //TODO: Figure out why you can't pass a file to reload
-  browserSync.reload();
+  browserSync.reload(files.path);
   //}
 };
 

--- a/tools/utils/seed/code_change_tools.ts
+++ b/tools/utils/seed/code_change_tools.ts
@@ -13,7 +13,7 @@ let runServer = () => {
     baseDir = `${DIST_DIR}/empty/`;
   }
 
-  browserSync({
+  browserSync.init({
     middleware: [require('connect-history-api-fallback')({index: `${APP_BASE}index.html`})],
     port: PORT,
     startPath: APP_BASE,
@@ -43,7 +43,8 @@ let changed = (files: any) => {
   // if (ENABLE_HOT_LOADING) {
   //   ng2HotLoader.onChange(files);
   // } else {
-  browserSync.reload(files);
+  //TODO: Figure out why you can't pass a file to reload
+  browserSync.reload();
   //}
 };
 

--- a/tools/utils/seed/server.ts
+++ b/tools/utils/seed/server.ts
@@ -9,6 +9,11 @@ export function serveSPA() {
   codeChangeTool.listen();
 }
 
+export function notifyLiveReload(e:any) {
+  let fileName = e.path;
+  codeChangeTool.changed(fileName);
+}
+
 export function serveDocs() {
   let server = express();
 

--- a/tools/utils/seed/watch.ts
+++ b/tools/utils/seed/watch.ts
@@ -1,12 +1,14 @@
-import * as gulp from 'gulp';
+import * as runSequence from 'run-sequence';
+import {notifyLiveReload} from '../../utils';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import {join} from 'path';
 import {APP_SRC} from '../../config';
 const plugins = <any>gulpLoadPlugins();
 
 export function watch(taskname: string) {
-  return () => {
-    plugins.watch(join(APP_SRC, '**/*'),
-      () => gulp.start(taskname));
+  return function () {
+    plugins.watch(join(APP_SRC, '**'), (e:any) =>
+      runSequence(taskname, () => notifyLiveReload(e))
+    );
   };
 }


### PR DESCRIPTION
> BrowserSync was not being notified on file change

- Takes BrowserSync back to last "real" release
- Adds function to notify BrowserSync
- Modifies watch task to notify on change
- Fixes file path semantics on reload()

Resolves #599 
Resolves #611