### PR TITLE
Move app_title and browser_list to project.config

### DIFF
--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -4,6 +4,21 @@ import {SeedConfig, normalizeDependencies} from './seed.config';
 export class ProjectConfig extends SeedConfig {
   PROJECT_TASKS_DIR = join(process.cwd(), this.TOOLS_DIR, 'tasks', 'project');
 
+  APP_TITLE = 'My Angular2 App';
+
+  // Autoprefixer configuration.
+  BROWSER_LIST = [
+    'ie >= 10',
+    'ie_mob >= 10',
+    'ff >= 30',
+    'chrome >= 34',
+    'safari >= 7',
+    'opera >= 23',
+    'ios >= 7',
+    'android >= 4.4',
+    'bb >= 10'
+  ];
+
   constructor() {
     super();
     // this.APP_TITLE = 'Put name of your app here';

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -23,8 +23,6 @@ export class SeedConfig {
 
   BOOTSTRAP_MODULE     = this.ENABLE_HOT_LOADING ? 'hot_loader_main' : 'main';
 
-  APP_TITLE            = 'My Angular2 App';
-
   APP_SRC              = 'src';
   ASSETS_SRC           = `${this.APP_SRC}/assets`;
 
@@ -109,19 +107,6 @@ export class SeedConfig {
     }
   };
 
-  // ----------------
-  // Autoprefixer configuration.
-  BROWSER_LIST = [
-    'ie >= 10',
-    'ie_mob >= 10',
-    'ff >= 30',
-    'chrome >= 34',
-    'safari >= 7',
-    'opera >= 23',
-    'ios >= 7',
-    'android >= 4.4',
-    'bb >= 10'
-  ];
   getEnvDependencies() {
     if (this.ENV === 'prod') {
       return this.PROD_DEPENDENCIES;


### PR DESCRIPTION
app_title and browser_list seem like project specific settings. Therefore, they should be defined in the `project.config.ts` instead of `seed.config.ts`

That way it is easier to overwrite `seeds.config.ts` every time there has been an update in angular2-seed.

Might even be an idea to create to following folders:
```bash
tools/
-- project
  -- config/
  -- tasks/
  -- utils/
-- seed
  -- config/
  -- tasks/
  -- utils/
```

That way you could easily update / clone angular2-seed again and just copy tools/seed to your project folder and you'll have all the fixes without having to compare it file to file.