### PR TITLE
chore: angular beta.13, rxjs beta.4, node 5+, npm 3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-- '4.0'
-- '4.1'
 - '5.1'
 sudo: false
 services:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It is something similar to the Angular Quick Start but does the entire build wit
 
 # How to start
 
-**Note** that this seed project requires node v4.x.x or higher and npm 2.14.7.
+**Note** that this seed project requires node v5.x.x or higher and npm 3 or higher.
 
 In order to start the seed use:
 

--- a/package.json
+++ b/package.json
@@ -105,12 +105,12 @@
     "yargs": "^4.2.0"
   },
   "dependencies": {
-    "angular2": "2.0.0-beta.12",
+    "angular2": "2.0.0-beta.13",
     "es6-module-loader": "^0.17.8",
     "es6-promise": "^3.1.2",
     "es6-shim": "0.35.0",
     "reflect-metadata": "0.1.2",
-    "rxjs": "5.0.0-beta.2",
+    "rxjs": "5.0.0-beta.4",
     "systemjs": "~0.19.18",
     "zone.js": "^0.6.6"
   }

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -44,8 +44,8 @@ export class SeedConfig {
   JS_PROD_SHIMS_BUNDLE = 'shims.js';
   JS_PROD_APP_BUNDLE   = 'app.js';
 
-  VERSION_NPM          = '2.14.2';
-  VERSION_NODE         = '4.0.0';
+  VERSION_NPM          = '3.0.0';
+  VERSION_NODE         = '5.0.0';
 
   CODELYZER_RULES      = customRules();
 


### PR DESCRIPTION
This introduces a debatable change for sure.

My arguments for changing to support only node 5+/npm 3+:

* Avoids peer dependency warnings which cause build failures on travis.
* Simplicity by supporting only node 5.1 on travis.
* Most new users will likely be using node 5+/npm 3+ combo.
* Allows for more progressive updates to occur more frequently because we wouldn't be held back by silly peer dependency warnings that 99% have no effect on successful build.

By maintaining support for < node 5, the seed will continue to be hindered by things like this:
```
npm WARN angular2@2.0.0-beta.13 requires a peer of rxjs@5.0.0-beta.2 but none was installed.
```

This is just a *warning* and not an error. Everything works well and afaik, rxjs beta.4 is better in many regards and continues to get better everyday.

/cc @mgechev @ludohenin 
