### PR TITLE
fix(build.bundles): add packageConfig path to the system builder config

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -132,6 +132,7 @@ export class SeedConfig {
 
   SYSTEM_BUILDER_CONFIG = {
     defaultJSExtensions: true,
+    packageConfigPaths: ['*/package.json'],
     paths: {
       [`${this.TMP_DIR}/*`]: `${this.TMP_DIR}/*`,
       '*': 'node_modules/*'


### PR DESCRIPTION
I needed to add this to match what is in the dev config. Without it when build.bundles.apps runs it won't find packages specified via package.json in the npm dep. 

If I dump the builder config after it's setup I can see it resolves to

```packageConfigPaths: [ 'file:///[path to my app]/node_modules/*/package.json' ],```

so looks like this is how it should be setup.