### PR TITLE
Update service worker

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -1,4 +1,4 @@
-var staticCacheName = 'angular2-seed-v2';
+var staticCacheName = 'angular2-seed-v1';
 self.addEventListener('activate', function(event) {
   console.log("Activated service worker");
   event.waitUntil(

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,12 +1,37 @@
-// Cache then network strategy
-// https://jakearchibald.com/2014/offline-cookbook/#cache-then-network
+var staticCacheName = 'angular2-seed-v2';
+self.addEventListener('activate', function(event) {
+  console.log("Activated service worker");
+  event.waitUntil(
+    caches.keys().then(function(cacheNames) {
+      return Promise.all(
+        cacheNames.filter(function(cacheName) {
+          return cacheName.startsWith('angular2-seed-') &&
+                 cacheName != staticCacheName;
+        }).map(function(cacheName) {
+          return caches.delete(cacheName);
+        })
+      );
+    })
+  );
+});
+
 self.addEventListener('fetch', function(event) {
+  if (event.request.method != 'GET') {
+     event.respondWith(fetch(event.request));
+     return;
+  }
   event.respondWith(
-    caches.open('angular2-seed').then(function(cache) {
-      return fetch(event.request).then(function(response) {
-        cache.put(event.request, response.clone());
-        return response;
-      });
+    caches.open(staticCacheName).then(function(cache) {
+      return cache.match(event.request).then(function(response) {
+        if (response) {
+          return response;
+        }
+        
+        return fetch(event.request).then(function(response) {
+          cache.put(event.request, response.clone());
+          return response;
+        });
+      })
     })
   );
 });


### PR DESCRIPTION
Old caches will be deleted when a new service worker gets activated, and it is easy to bump the cache version.

SW [cannot cache POST requests](http://stackoverflow.com/questions/35270702/) and no longer registers them as an error (see request method check in the `fetch` event listener).

SW will only go to network if it needs to, and is capable of working offline

*This can be a current sw solution until full progressive support is enabled