### PR TITLE
refactor(seed.config): remove redundant call to `path.normalize()`

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -1,5 +1,5 @@
 import {argv} from 'yargs';
-import {normalize, join} from 'path';
+import {join} from 'path';
 import {InjectableDependency, Environments} from './seed.config.interfaces';
 
 export const ENVIRONMENTS: Environments = {
@@ -10,7 +10,7 @@ export const ENVIRONMENTS: Environments = {
 
 export class SeedConfig {
   PORT                 = argv['port']                        || 5555;
-  PROJECT_ROOT         = normalize(join(__dirname, '..'));
+  PROJECT_ROOT         = join(__dirname, '..');
   ENV                  = getEnvironment();
   DEBUG                = argv['debug']                       || false;
   DOCS_PORT            = argv['docs-port']                   || 4003;


### PR DESCRIPTION
`path.join()` normalizes the resulting path anyway. There is no need to call `path.normalize()` explicitly.