### PR TITLE
fix(build.bundles): add packageConfigPaths so bundlers will work with modules using package.json

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -132,6 +132,7 @@ export class SeedConfig {
 
   SYSTEM_BUILDER_CONFIG = {
     defaultJSExtensions: true,
+    packageConfigPaths: [join(this.PROJECT_ROOT, 'node_modules', '*', 'package.json')],
     paths: {
       [`${this.TMP_DIR}/*`]: `${this.TMP_DIR}/*`,
       '*': 'node_modules/*'


### PR DESCRIPTION
The changes/reverts from #712 left this broken for prod builds again. 

From the looks of the error messages the underlying issue was related to the paths being broken when they were normalized on windows, I think it may of been dropping the * which is supposed to be replaced by the npm module name.

I don't have a windows dev machine to test this on, but this seems to work okay on my mac. I like to imagine it will fix the windows issue from #712 too since it should be providing the full path in the correct format for the OS.