### PR TITLE
chore(devDeps): Update rempa-istanbul to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "phantomjs-prebuilt": "^2.1.4",
     "postcss-reporter": "^1.3.3",
     "protractor": "^3.0.0",
-    "remap-istanbul": "git+https://github.com/SitePen/remap-istanbul.git#master",
+    "remap-istanbul": "^0.6.1",
     "rimraf": "^2.5.2",
     "run-sequence": "^1.1.0",
     "semver": "^5.1.0",


### PR DESCRIPTION
  - Moves off of the master branch
  - 0.6.1 contains the absolute path fixes needed for the seed

Resolves #762