### PR TITLE
fix(tools): Use ASSET_SRC parameter from SeedConfig instead of recons…

### DIFF
--- a/tools/tasks/seed/css-lint.ts
+++ b/tools/tasks/seed/css-lint.ts
@@ -6,7 +6,7 @@ import * as stylelint from 'stylelint';
 import * as doiuse from 'doiuse';
 import * as colorguard from 'colorguard';
 import {join} from 'path';
-import {APP_SRC, APP_ASSETS, BROWSER_LIST, ENV} from '../../config';
+import {APP_SRC, APP_ASSETS, ASSETS_SRC, BROWSER_LIST, ENV} from '../../config';
 const plugins = <any>gulpLoadPlugins();
 
 const isProd = ENV === 'prod';
@@ -23,7 +23,7 @@ const processors = [
 function lintComponentCss() {
   return gulp.src([
       join(APP_SRC, '**', '*.css'),
-      '!' + join(APP_SRC, 'assets', '**', '*.css')
+      '!' + join(ASSETS_SRC, '**', '*.css')
     ])
     .pipe(isProd ? plugins.cached('css-lint') : plugins.util.noop())
     .pipe(plugins.postcss(processors));


### PR DESCRIPTION
Instead of constructing the assets folder path inside css-lint.ts i have changed it to use the already in place parameter inside of the SeedConfig. this way if the assets folder is moved or renamed the css lint would still work.