### PR TITLE
Will clean out the dist/dev directory contents

### DIFF
--- a/tools/tasks/seed/clean.dev.ts
+++ b/tools/tasks/seed/clean.dev.ts
@@ -1,5 +1,5 @@
-import {DEV_DEST} from '../config';
-import {clean} from '../utils';
+import {DEV_DEST} from '../../config';
+import {clean} from '../../utils';
 import {readdirSync} from 'fs';
 import {join} from 'path';
 

--- a/tools/tasks/seed/clean.dev.ts
+++ b/tools/tasks/seed/clean.dev.ts
@@ -1,4 +1,11 @@
-import {DEV_DEST} from '../../config';
-import {clean} from '../../utils';
+import {DEV_DEST} from '../config';
+import {clean} from '../utils';
+import {readdirSync} from 'fs';
+import {join} from 'path';
 
-export = clean(DEV_DEST)
+export = clean(getSubPaths(DEV_DEST))
+
+function getSubPaths(path: string) {
+    let files = readdirSync(path);
+    return files.map((file:string) => join(path, file));
+}


### PR DESCRIPTION
The karma.conf.js has a file watcher on:

```
{ pattern: 'dist/dev/**/*.js', included: false, watched: true }
```

When working with the build.test.watch gulp task, every file change runs the clean.dev task which currently deletes the dist/dev directory. The new build is then dropped in to a new /dist/dev directory which the karma test file watcher does not know about.

This fix keeps the /dist/dev directory but cleans out its contents.