### PR TITLE
Fixes path for css-lint task

### DIFF
--- a/tools/tasks/seed/css-lint.ts
+++ b/tools/tasks/seed/css-lint.ts
@@ -6,7 +6,7 @@ import * as stylelint from 'stylelint';
 import * as doiuse from 'doiuse';
 import * as colorguard from 'colorguard';
 import {join} from 'path';
-import {APP_SRC, APP_ASSETS, ASSETS_SRC, BROWSER_LIST, ENV} from '../../config';
+import {APP_SRC, APP_ASSETS, BROWSER_LIST, CSS_SRC, ENV} from '../../config';
 const plugins = <any>gulpLoadPlugins();
 
 const isProd = ENV === 'prod';
@@ -23,7 +23,7 @@ const processors = [
 function lintComponentCss() {
   return gulp.src([
       join(APP_SRC, '**', '*.css'),
-      '!' + join(ASSETS_SRC, '**', '*.css')
+      '!' + join(CSS_SRC, '**', '*.css')
     ])
     .pipe(isProd ? plugins.cached('css-lint') : plugins.util.noop())
     .pipe(plugins.postcss(processors));


### PR DESCRIPTION
Corrects the path for the css-lint task after the refactoring
of the main.css into client/css (before: assets)

Hi there, i am not quite sure if i got this right, but after the commit https://github.com/mgechev/angular2-seed/commit/aa9ad6ab32cf568fcf93f4b5e1c77d095c33c8a2 introduced a dedicated css directory under client/css i think the css-lint task has to point to this new directory.

If i got it wrong, then i am sorry, feel free to abandon this pull request.

Greetings

