### PR TITLE
Fixes component spec tests

### DIFF
--- a/src/client/app/+about/components/about.component.spec.ts
+++ b/src/client/app/+about/components/about.component.spec.ts
@@ -1,7 +1,6 @@
 import {
   TestComponentBuilder,
   describe,
-  expect,
   injectAsync,
   it
 } from 'angular2/testing';

--- a/src/client/app/+home/components/home.component.spec.ts
+++ b/src/client/app/+home/components/home.component.spec.ts
@@ -1,7 +1,6 @@
 import {
   TestComponentBuilder,
   describe,
-  expect,
   injectAsync,
   it
 } from 'angular2/testing';

--- a/src/client/app/components/app.component.spec.ts
+++ b/src/client/app/components/app.component.spec.ts
@@ -1,7 +1,6 @@
 import {
   TestComponentBuilder,
   describe,
-  expect,
   injectAsync,
   it,
   beforeEachProviders


### PR DESCRIPTION
Removes the `expect` import from the spec files, since those import
NgMatchers which only contain Angular specific jasmine matchers.
However the current tests just use standard jasmine matchers.

---

Currently, the `expect` import leads to importing `NgMatchers` (https://angular.io/docs/ts/latest/api/testing/NgMatchers-interface.html), which defines the following Angular specific jasmine matchers:

- `not`
- `toBeAnInstanceOf`
- `toBePromise`
- `toContainError`
- `toHaveCssClass`
- `toHaveCssStyle`
- `toHaveText`
- `toImplement`
- `toMatchPattern`
- `toThrowErrorWith`

Some of those are not yet documented in the API documentation (see above link).

Since those matchers are Angular specific and do not cover all of the currently used jasmine matchers (which makes sense, since they only provide angular specifics) i propose to remove the import and work with the default jasmine matchers.

Greetings

Dope