### PR TITLE
chore(tools): expose browserSync configuration

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -112,6 +112,7 @@ export class SeedConfig {
       .concat(this.APP_ASSETS.filter(filterDependency.bind(null, this.ENV)));
   }
 
+
   // ----------------
   // SystemsJS Configuration.
   protected SYSTEM_CONFIG_DEV = {
@@ -154,6 +155,23 @@ export class SeedConfig {
     'android >= 4.4',
     'bb >= 10'
   ];
+
+  // ----------------
+  // Browser Sync configuration.
+  BROWSER_SYNC_CONFIG: any = {
+    middleware: [require('connect-history-api-fallback')({index: `${this.APP_BASE}index.html`})],
+    port: this.PORT,
+    startPath: this.APP_BASE,
+    server: {
+      baseDir: `${this.DIST_DIR}/empty/`,
+      routes: {
+        [`${this.APP_BASE}${this.APP_DEST}`]: this.APP_DEST,
+        [`${this.APP_BASE}node_modules`]: 'node_modules',
+        [`${this.APP_BASE.replace(/\/$/,'')}`]: this.APP_DEST
+      }
+    }
+  };
+
   getEnvDependencies() {
     console.warn('The "getEnvDependencies" method is deprecated. Consider using "DEPENDENCIES" instead.');
     if (this.ENV === 'prod') {

--- a/tools/utils/seed/code_change_tools.ts
+++ b/tools/utils/seed/code_change_tools.ts
@@ -1,27 +1,8 @@
-import {PORT, APP_DEST, APP_BASE, DIST_DIR} from '../../config';
+import {BROWSER_SYNC_CONFIG} from '../../config';
 import * as browserSync from 'browser-sync';
 
 let runServer = () => {
-  let baseDir = APP_DEST;
-  let routes:any = {
-    [`${APP_BASE}${APP_DEST}`]: APP_DEST,
-    [`${APP_BASE}node_modules`]: 'node_modules',
-  };
-
-  if (APP_BASE !== '/') {
-    routes[`${APP_BASE}`] = APP_DEST;
-    baseDir = `${DIST_DIR}/empty/`;
-  }
-
-  browserSync.init({
-    middleware: [require('connect-history-api-fallback')({index: `${APP_BASE}index.html`})],
-    port: PORT,
-    startPath: APP_BASE,
-    server: {
-      baseDir: baseDir,
-      routes: routes
-    }
-  });
+  browserSync.init(BROWSER_SYNC_CONFIG);
 };
 
 let listen = () => {


### PR DESCRIPTION
Exposes the browserSync configuration to the seed configuration. Can now easily be overridden.