### PR TITLE
perf update -> css streaming

### DIFF
--- a/tools/utils/seed/code_change_tools.ts
+++ b/tools/utils/seed/code_change_tools.ts
@@ -1,6 +1,6 @@
 import {BROWSER_SYNC_CONFIG} from '../../config';
 import * as browserSync from 'browser-sync';
-let path = require('path');
+import * as path from 'path';
 
 let runServer = () => {
   browserSync.init(BROWSER_SYNC_CONFIG);

--- a/tools/utils/seed/code_change_tools.ts
+++ b/tools/utils/seed/code_change_tools.ts
@@ -26,7 +26,7 @@ let changed = (files: any) => {
   let onlyStylesChanged =
     files
       .map((f:string) => path.parse(f).ext)
-      .reduce((prev:string, current:string) => prev && (current === ".scss" || current === ".css"), true);
+      .reduce((prev:string, current:string) => prev && (current === '.scss' || current === '.css'), true);
 
   // if (ENABLE_HOT_LOADING) {
   //   ng2HotLoader.onChange(files);
@@ -34,8 +34,8 @@ let changed = (files: any) => {
   //TODO: Figure out why you can't pass a file to reload
   if (onlyStylesChanged === false) {
     browserSync.reload(files);
-  }else{
-    browserSync.reload("*.css")
+  }else {
+    browserSync.reload('*.css');
   }
   //}
 };

--- a/tools/utils/seed/code_change_tools.ts
+++ b/tools/utils/seed/code_change_tools.ts
@@ -1,5 +1,6 @@
 import {BROWSER_SYNC_CONFIG} from '../../config';
 import * as browserSync from 'browser-sync';
+let path = require('path');
 
 let runServer = () => {
   browserSync.init(BROWSER_SYNC_CONFIG);
@@ -21,11 +22,21 @@ let changed = (files: any) => {
   if (!(files instanceof Array)) {
     files = [files];
   }
+
+  let onlyStylesChanged =
+    files
+      .map((f:string) => path.parse(f).ext)
+      .reduce((prev:string, current:string) => prev && (current === ".scss" || current === ".css"), true);
+
   // if (ENABLE_HOT_LOADING) {
   //   ng2HotLoader.onChange(files);
   // } else {
   //TODO: Figure out why you can't pass a file to reload
-  browserSync.reload(files.path);
+  if (onlyStylesChanged === false) {
+    browserSync.reload(files);
+  }else{
+    browserSync.reload("*.css")
+  }
   //}
 };
 


### PR DESCRIPTION
Enabling the streaming of css files handled by browsersync.
Will look through the list of changed file and if only css or scss file was changed, then all css files will be internally reloaded per stream by browsersync. If some other file type is found amongst the changed one - a standard  reload will occur.

It works nicely with scss, when a separate task compiles a concat file containing all of the styles and a normal watch will only find the scss files, as they are the ones lying in the project scope.

Note that component scoped css files will not be covered by this as they are loaded by angular directly.

Addresses #804.