### PR TITLE
Ignoring editor temporary files

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -66,6 +66,12 @@ export class SeedConfig {
     { src: `${this.CSS_SRC}/main.css`, inject: true, vendor: false }
   ];
 
+  // Editor temporary files to ignore in watcher and asset builder.
+  TEMP_FILES: string[] = [
+    '**/*___jb_tmp___',
+    '**/*~',
+  ];
+
   get DEPENDENCIES(): InjectableDependency[] {
     return normalizeDependencies(this.NPM_DEPENDENCIES.filter(filterDependency.bind(null, this.ENV)))
       .concat(this.APP_ASSETS.filter(filterDependency.bind(null, this.ENV)));

--- a/tools/tasks/seed/build.assets.dev.ts
+++ b/tools/tasks/seed/build.assets.dev.ts
@@ -1,11 +1,13 @@
 import * as gulp from 'gulp';
 import {join} from 'path';
-import {APP_SRC, APP_DEST} from '../../config';
+import {APP_SRC, APP_DEST, TEMP_FILES} from '../../config';
 
 export = () => {
-  return gulp.src([
-      join(APP_SRC, '**'),
-      '!' + join(APP_SRC, '**', '*.ts')
-    ])
+  let paths:string[]=[
+    join(APP_SRC, '**'),
+    '!' + join(APP_SRC, '**', '*.ts')
+  ].concat(TEMP_FILES.map((p) => { return '!'+p }));
+
+  return gulp.src(paths)
     .pipe(gulp.dest(APP_DEST));
 }

--- a/tools/tasks/seed/build.assets.dev.ts
+++ b/tools/tasks/seed/build.assets.dev.ts
@@ -6,7 +6,7 @@ export = () => {
   let paths:string[]=[
     join(APP_SRC, '**'),
     '!' + join(APP_SRC, '**', '*.ts')
-  ].concat(TEMP_FILES.map((p) => { return '!'+p }));
+  ].concat(TEMP_FILES.map((p) => { return '!'+p; }));
 
   return gulp.src(paths)
     .pipe(gulp.dest(APP_DEST));

--- a/tools/tasks/seed/build.assets.prod.ts
+++ b/tools/tasks/seed/build.assets.prod.ts
@@ -21,7 +21,7 @@ export = () => {
       '!' + join(APP_SRC, '**', '*.css'),
       '!' + join(APP_SRC, '**', '*.html'),
       '!' + join(ASSETS_SRC, '**', '*.js')
-    ].concat(TEMP_FILES.map((p) => { return '!'+p })))
+    ].concat(TEMP_FILES.map((p) => { return '!'+p; })))
     .pipe(onlyDirs(es))
     .pipe(gulp.dest(APP_DEST));
 }

--- a/tools/tasks/seed/build.assets.prod.ts
+++ b/tools/tasks/seed/build.assets.prod.ts
@@ -1,6 +1,6 @@
 import * as gulp from 'gulp';
 import {join} from 'path';
-import {APP_SRC, APP_DEST, ASSETS_SRC} from '../../config';
+import {APP_SRC, APP_DEST, ASSETS_SRC, TEMP_FILES} from '../../config';
 
 // TODO There should be more elegant to prevent empty directories from copying
 let es: any = require('event-stream');
@@ -21,7 +21,7 @@ export = () => {
       '!' + join(APP_SRC, '**', '*.css'),
       '!' + join(APP_SRC, '**', '*.html'),
       '!' + join(ASSETS_SRC, '**', '*.js')
-    ])
+    ].concat(TEMP_FILES.map((p) => { return '!'+p })))
     .pipe(onlyDirs(es))
     .pipe(gulp.dest(APP_DEST));
 }

--- a/tools/utils/seed/watch.ts
+++ b/tools/utils/seed/watch.ts
@@ -2,12 +2,16 @@ import * as runSequence from 'run-sequence';
 import {notifyLiveReload} from '../../utils';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import {join} from 'path';
-import {APP_SRC} from '../../config';
+import {APP_SRC,TEMP_FILES} from '../../config';
 const plugins = <any>gulpLoadPlugins();
 
 export function watch(taskname: string) {
   return function () {
-    plugins.watch(join(APP_SRC, '**'), (e:any) =>
+    let paths:string[]=[
+      join(APP_SRC,'**')
+    ].concat(TEMP_FILES.map((p) => { return '!'+p }));
+
+    plugins.watch(paths, (e:any) =>
       runSequence(taskname, () => notifyLiveReload(e))
     );
   };

--- a/tools/utils/seed/watch.ts
+++ b/tools/utils/seed/watch.ts
@@ -9,7 +9,7 @@ export function watch(taskname: string) {
   return function () {
     let paths:string[]=[
       join(APP_SRC,'**')
-    ].concat(TEMP_FILES.map((p) => { return '!'+p }));
+    ].concat(TEMP_FILES.map((p) => { return '!'+p; }));
 
     plugins.watch(paths, (e:any) =>
       runSequence(taskname, () => notifyLiveReload(e))


### PR DESCRIPTION
This is a fix for #821 -- ignoring temporary files from editors when
watching and building.