### PR TITLE
Changed the concatenation of css files to use concatCss instead of co…

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "gulp-uglify": "^1.5.3",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.3.5",
+    "gulp-concat-css": "^2.2.0",
+    "gulp-clean-css": "^2.0.7",
     "is-ci": "^1.0.8",
     "isstream": "^0.1.2",
     "jasmine-core": "~2.4.1",

--- a/tools/tasks/seed/build.html_css.ts
+++ b/tools/tasks/seed/build.html_css.ts
@@ -6,6 +6,7 @@ import * as cssnano from 'cssnano';
 import {join} from 'path';
 import {APP_SRC, TMP_DIR, CSS_PROD_BUNDLE, CSS_DEST, APP_DEST, BROWSER_LIST, ENV, DEPENDENCIES} from '../../config';
 const plugins = <any>gulpLoadPlugins();
+let cleanCss = require('gulp-clean-css');
 
 const processors = [
   autoprefixer({
@@ -42,7 +43,8 @@ function processExternalCss() {
   return gulp.src(getExternalCss().map(r => r.src))
     .pipe(isProd ? plugins.cached('process-external-css') : plugins.util.noop())
     .pipe(plugins.postcss(processors))
-    .pipe(isProd ? plugins.concat(CSS_PROD_BUNDLE) : plugins.util.noop())
+    .pipe(isProd ? plugins.concatCss(CSS_PROD_BUNDLE) : plugins.util.noop())
+    .pipe(isProd ? cleanCss() : plugins.util.noop())
     .pipe(gulp.dest(CSS_DEST));
 }
 


### PR DESCRIPTION
Currently if any files use the @import feature of css it is being ignored by the build.
This is not a problem when using files from inside the project as they are being included anyway but when using 3rd party library if it uses @import on its own files they will not be included in the prod build(as they are not present) and even if added forcefully to the project will throw runtime errors in the browser for missing files.

This pr fixes this by changing the use of gulp-concat for css files with gulp-cssConcat which handles @import statements correctly.
Also because gulp-cssConcat does not automatically minify the code I added the use of gulp-cleanCss.