### PR TITLE
Adding types to SYSTEM_CONFIG_DEV and SYSTEM_BUILDER_CONFIG objects

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -77,7 +77,7 @@ export class SeedConfig {
 
   // ----------------
   // SystemsJS Configuration.
-  protected SYSTEM_CONFIG_DEV = {
+  protected SYSTEM_CONFIG_DEV: any = {
     defaultJSExtensions: true,
     packageConfigPaths: [
       `${this.APP_BASE}node_modules/*/package.json`,
@@ -97,7 +97,7 @@ export class SeedConfig {
 
   SYSTEM_CONFIG = this.SYSTEM_CONFIG_DEV;
 
-  SYSTEM_BUILDER_CONFIG = {
+  SYSTEM_BUILDER_CONFIG: any = {
     defaultJSExtensions: true,
     packageConfigPaths: [
       join(this.PROJECT_ROOT, 'node_modules', '*', 'package.json'),


### PR DESCRIPTION
This PR adds the type of "any" to the SYSTEM_CONFIG_DEV and SYSTEM_BUILDER_CONFIG objects in seed.config.ts. Adding these types makes typscript happy and allows for the config objects from project.config.ts to do things like add lodash like it's done in [angular-seed-advanced](https://github.com/NathanWalker/angular2-seed-advanced).

Example:
``` javascript
this.SYSTEM_CONFIG.paths['lodash'] = `${this.APP_BASE}node_modules/lodash/index`;
this.SYSTEM_BUILDER_CONFIG.paths['lodash'] = `node_modules/lodash/index.js`;
```