### PR TITLE
style: import destructuring spacing

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -1,7 +1,7 @@
 import * as gulp from 'gulp';
 import * as runSequence from 'run-sequence';
-import {loadTasks} from './tools/utils';
-import {SEED_TASKS_DIR, PROJECT_TASKS_DIR} from './tools/config';
+import { loadTasks } from './tools/utils';
+import { SEED_TASKS_DIR, PROJECT_TASKS_DIR } from './tools/config';
 
 loadTasks(SEED_TASKS_DIR);
 loadTasks(PROJECT_TASKS_DIR);

--- a/src/client/app/+about/components/about.component.spec.ts
+++ b/src/client/app/+about/components/about.component.spec.ts
@@ -4,10 +4,10 @@ import {
   inject,
   it
 } from '@angular/core/testing';
-import {TestComponentBuilder} from '@angular/compiler/testing';
-import {Component} from '@angular/core';
-import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
-import {AboutComponent} from './about.component';
+import { TestComponentBuilder } from '@angular/compiler/testing';
+import { Component } from '@angular/core';
+import { getDOM } from '@angular/platform-browser/src/dom/dom_adapter';
+import { AboutComponent } from './about.component';
 
 export function main() {
   describe('About component', () => {

--- a/src/client/app/+about/components/about.component.ts
+++ b/src/client/app/+about/components/about.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'sd-about',

--- a/src/client/app/+home/components/home.component.spec.ts
+++ b/src/client/app/+home/components/home.component.spec.ts
@@ -4,12 +4,11 @@ import {
   it,
   inject
 } from '@angular/core/testing';
-import {TestComponentBuilder} from '@angular/compiler/testing';
-import {Component} from '@angular/core';
-import {getDOM} from '@angular/platform-browser/src/dom/dom_adapter';
-import {HomeComponent} from './home.component';
-import {NameListService} from '../../shared/index';
-
+import { TestComponentBuilder } from '@angular/compiler/testing';
+import { Component } from '@angular/core';
+import { getDOM } from '@angular/platform-browser/src/dom/dom_adapter';
+import { HomeComponent } from './home.component';
+import { NameListService } from '../../shared/index';
 
 export function main() {
   describe('Home component', () => {

--- a/src/client/app/+home/components/home.component.ts
+++ b/src/client/app/+home/components/home.component.ts
@@ -1,7 +1,7 @@
-import {Component} from '@angular/core';
-import {FORM_DIRECTIVES} from '@angular/common';
+import { Component } from '@angular/core';
+import { FORM_DIRECTIVES } from '@angular/common';
 
-import {NameListService} from '../../shared/index';
+import { NameListService } from '../../shared/index';
 
 @Component({
   selector: 'sd-home',

--- a/src/client/app/components/app.component.spec.ts
+++ b/src/client/app/components/app.component.spec.ts
@@ -6,12 +6,12 @@ import {
   async,
   beforeEachProviders
 } from '@angular/core/testing';
-import {TestComponentBuilder} from '@angular/compiler/testing';
-import {Component} from '@angular/core';
+import { TestComponentBuilder } from '@angular/compiler/testing';
+import { Component } from '@angular/core';
 
-import {ROUTER_FAKE_PROVIDERS} from '@angular/router/testing';
+import { ROUTER_FAKE_PROVIDERS } from '@angular/router/testing';
 
-import {AppComponent} from './app.component';
+import { AppComponent } from './app.component';
 
 export function main() {
 

--- a/src/client/app/components/app.component.ts
+++ b/src/client/app/components/app.component.ts
@@ -1,10 +1,10 @@
-import {Component} from '@angular/core';
-import {ROUTER_DIRECTIVES, Routes} from '@angular/router';
-import {NavbarComponent} from './navbar.component';
-import {ToolbarComponent} from './toolbar.component';
-import {NameListService} from '../shared/index';
-import {HomeComponent} from '../+home/index';
-import {AboutComponent} from '../+about/index';
+import { Component } from '@angular/core';
+import { ROUTER_DIRECTIVES, Routes } from '@angular/router';
+import { NavbarComponent } from './navbar.component';
+import { ToolbarComponent } from './toolbar.component';
+import { NameListService } from '../shared/index';
+import { HomeComponent } from '../+home/index';
+import { AboutComponent } from '../+about/index';
 
 @Component({
   selector: 'sd-app',

--- a/src/client/app/components/navbar.component.ts
+++ b/src/client/app/components/navbar.component.ts
@@ -1,5 +1,5 @@
-import {Component} from '@angular/core';
-import {ROUTER_DIRECTIVES} from '@angular/router';
+import { Component } from '@angular/core';
+import { ROUTER_DIRECTIVES } from '@angular/router';
 
 @Component({
   selector: 'sd-navbar',

--- a/src/client/app/components/toolbar.component.ts
+++ b/src/client/app/components/toolbar.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'sd-toolbar',

--- a/src/client/app/shared/services/name-list.service.spec.ts
+++ b/src/client/app/shared/services/name-list.service.spec.ts
@@ -1,4 +1,4 @@
-import {NameListService} from './name-list.service';
+import { NameListService } from './name-list.service';
 
 export function main() {
   describe('NameList Service', () => {

--- a/src/client/hot_loader_main.ts
+++ b/src/client/hot_loader_main.ts
@@ -1,8 +1,8 @@
 // Hot loading is temporary disabled
 //
-// import {provide} from 'angular2/core';
-// import {ROUTER_PROVIDERS, LocationStrategy, HashLocationStrategy} from 'angular2/router';
-// import {AppCmp} from './app/components/app';
+// import { provide } from 'angular2/core';
+// import { ROUTER_PROVIDERS, LocationStrategy, HashLocationStrategy } from 'angular2/router';
+// import { AppCmp } from './app/components/app';
 
 // System.import('//localhost:<%= HOT_LOADER_PORT %>/ng2-hot-loader')
 //   .then(loader => {

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -1,8 +1,8 @@
-import {provide, enableProdMode} from '@angular/core';
-import {bootstrap} from '@angular/platform-browser-dynamic';
-import {ROUTER_PROVIDERS} from '@angular/router';
-import {APP_BASE_HREF} from '@angular/common';
-import {AppComponent} from './app/components/app.component';
+import { provide, enableProdMode } from '@angular/core';
+import { bootstrap } from '@angular/platform-browser-dynamic';
+import { ROUTER_PROVIDERS } from '@angular/router';
+import { APP_BASE_HREF } from '@angular/common';
+import { AppComponent } from './app/components/app.component';
 
 if ('<%= ENV %>' === 'prod') { enableProdMode(); }
 

--- a/tools/config.ts
+++ b/tools/config.ts
@@ -1,4 +1,4 @@
-import {ProjectConfig} from './config/project.config';
+import { ProjectConfig } from './config/project.config';
 
 const config: ProjectConfig = new ProjectConfig();
 export = config;

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -1,6 +1,6 @@
-import {join} from 'path';
-import {SeedConfig} from './seed.config';
-import {InjectableDependency} from './seed.config.interfaces';
+import { join } from 'path';
+import { SeedConfig } from './seed.config';
+import { InjectableDependency } from './seed.config.interfaces';
 
 export class ProjectConfig extends SeedConfig {
   PROJECT_TASKS_DIR = join(process.cwd(), this.TOOLS_DIR, 'tasks', 'project');

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -1,6 +1,6 @@
-import {argv} from 'yargs';
-import {join} from 'path';
-import {InjectableDependency, Environments} from './seed.config.interfaces';
+import { argv } from 'yargs';
+import { join } from 'path';
+import { InjectableDependency, Environments } from './seed.config.interfaces';
 
 export const ENVIRONMENTS: Environments = {
   DEVELOPMENT: 'dev',

--- a/tools/debug.ts
+++ b/tools/debug.ts
@@ -1,4 +1,4 @@
-import {argv} from 'yargs';
+import { argv } from 'yargs';
 import * as gulp from 'gulp';
 
 require('../gulpfile');

--- a/tools/manual_typings/seed/express-history-api-fallback.d.ts
+++ b/tools/manual_typings/seed/express-history-api-fallback.d.ts
@@ -1,6 +1,6 @@
 declare module 'express-history-api-fallback' {
 
-  import {RequestHandler} from 'express';
+  import { RequestHandler } from 'express';
 
   interface IOptions {
     maxAge?: number,

--- a/tools/tasks/project/sample.task.ts
+++ b/tools/tasks/project/sample.task.ts
@@ -1,6 +1,6 @@
 import * as gulp from 'gulp';
-import {join} from 'path';
-import {APP_SRC, APP_DEST} from '../../config';
+import { join } from 'path';
+import { APP_SRC, APP_DEST } from '../../config';
 
 /**
  * Sample tasks

--- a/tools/tasks/seed/build.assets.dev.ts
+++ b/tools/tasks/seed/build.assets.dev.ts
@@ -1,6 +1,6 @@
 import * as gulp from 'gulp';
-import {join} from 'path';
-import {APP_SRC, APP_DEST, TEMP_FILES} from '../../config';
+import { join } from 'path';
+import { APP_SRC, APP_DEST, TEMP_FILES } from '../../config';
 
 export = () => {
   let paths:string[]=[

--- a/tools/tasks/seed/build.assets.prod.ts
+++ b/tools/tasks/seed/build.assets.prod.ts
@@ -1,6 +1,6 @@
 import * as gulp from 'gulp';
-import {join} from 'path';
-import {APP_SRC, APP_DEST, ASSETS_SRC, TEMP_FILES} from '../../config';
+import { join } from 'path';
+import { APP_SRC, APP_DEST, ASSETS_SRC, TEMP_FILES } from '../../config';
 
 // TODO There should be more elegant to prevent empty directories from copying
 let es: any = require('event-stream');

--- a/tools/tasks/seed/build.bundles.app.ts
+++ b/tools/tasks/seed/build.bundles.app.ts
@@ -1,4 +1,4 @@
-import {join} from 'path';
+import { join } from 'path';
 import * as Builder from 'systemjs-builder';
 import {
   BOOTSTRAP_MODULE,

--- a/tools/tasks/seed/build.bundles.ts
+++ b/tools/tasks/seed/build.bundles.ts
@@ -1,7 +1,7 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import * as merge from 'merge-stream';
-import {DEPENDENCIES, JS_PROD_SHIMS_BUNDLE, JS_DEST} from '../../config';
+import { DEPENDENCIES, JS_PROD_SHIMS_BUNDLE, JS_DEST } from '../../config';
 const plugins = <any>gulpLoadPlugins();
 
 export = () => merge(bundleShims());

--- a/tools/tasks/seed/build.docs.ts
+++ b/tools/tasks/seed/build.docs.ts
@@ -1,7 +1,7 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
-import {join} from 'path';
-import {APP_SRC, APP_TITLE, DOCS_DEST} from '../../config';
+import { join } from 'path';
+import { APP_SRC, APP_TITLE, DOCS_DEST } from '../../config';
 const plugins = <any>gulpLoadPlugins();
 
 export = () => {

--- a/tools/tasks/seed/build.html_css.ts
+++ b/tools/tasks/seed/build.html_css.ts
@@ -3,8 +3,8 @@ import * as gulpLoadPlugins from 'gulp-load-plugins';
 import * as merge from 'merge-stream';
 import * as autoprefixer from 'autoprefixer';
 import * as cssnano from 'cssnano';
-import {join} from 'path';
-import {APP_SRC, TMP_DIR, CSS_PROD_BUNDLE, CSS_DEST, APP_DEST, BROWSER_LIST, ENV, DEPENDENCIES} from '../../config';
+import { join } from 'path';
+import { APP_SRC, TMP_DIR, CSS_PROD_BUNDLE, CSS_DEST, APP_DEST, BROWSER_LIST, ENV, DEPENDENCIES } from '../../config';
 const plugins = <any>gulpLoadPlugins();
 let cleanCss = require('gulp-clean-css');
 

--- a/tools/tasks/seed/build.index.dev.ts
+++ b/tools/tasks/seed/build.index.dev.ts
@@ -1,9 +1,9 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
-import {join} from 'path';
+import { join } from 'path';
 import * as slash from 'slash';
-import {APP_SRC, APP_DEST, APP_BASE, DEPENDENCIES} from '../../config';
-import {templateLocals} from '../../utils';
+import { APP_SRC, APP_DEST, APP_BASE, DEPENDENCIES } from '../../config';
+import { templateLocals } from '../../utils';
 const plugins = <any>gulpLoadPlugins();
 
 export = () => {

--- a/tools/tasks/seed/build.index.prod.ts
+++ b/tools/tasks/seed/build.index.prod.ts
@@ -1,8 +1,8 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
-import {join, sep, normalize} from 'path';
+import { join, sep, normalize } from 'path';
 import * as slash from 'slash';
-import {templateLocals} from '../../utils';
+import { templateLocals } from '../../utils';
 import {
   APP_BASE,
   APP_SRC,

--- a/tools/tasks/seed/build.js.dev.ts
+++ b/tools/tasks/seed/build.js.dev.ts
@@ -1,9 +1,9 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import * as merge from 'merge-stream';
-import {join} from 'path';
-import {APP_SRC, APP_DEST, TOOLS_DIR} from '../../config';
-import {templateLocals, makeTsProject} from '../../utils';
+import { join } from 'path';
+import { APP_SRC, APP_DEST, TOOLS_DIR } from '../../config';
+import { templateLocals, makeTsProject } from '../../utils';
 const plugins = <any>gulpLoadPlugins();
 
 export = () => {

--- a/tools/tasks/seed/build.js.e2e.ts
+++ b/tools/tasks/seed/build.js.e2e.ts
@@ -1,8 +1,8 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
-import {join} from 'path';
-import {APP_SRC, APP_DEST, TOOLS_DIR} from '../../config';
-import {templateLocals, makeTsProject} from '../../utils';
+import { join } from 'path';
+import { APP_SRC, APP_DEST, TOOLS_DIR } from '../../config';
+import { templateLocals, makeTsProject } from '../../utils';
 const plugins = <any>gulpLoadPlugins();
 
 

--- a/tools/tasks/seed/build.js.prod.ts
+++ b/tools/tasks/seed/build.js.prod.ts
@@ -1,8 +1,8 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
-import {join} from 'path';
-import {TMP_DIR, TOOLS_DIR} from '../../config';
-import {templateLocals, makeTsProject} from '../../utils';
+import { join } from 'path';
+import { TMP_DIR, TOOLS_DIR } from '../../config';
+import { templateLocals, makeTsProject } from '../../utils';
 const plugins = <any>gulpLoadPlugins();
 
 const INLINE_OPTIONS = {

--- a/tools/tasks/seed/build.js.test.ts
+++ b/tools/tasks/seed/build.js.test.ts
@@ -1,8 +1,8 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
-import {join} from 'path';
-import {BOOTSTRAP_MODULE, APP_SRC, APP_DEST, TOOLS_DIR} from '../../config';
-import {makeTsProject} from '../../utils';
+import { join } from 'path';
+import { BOOTSTRAP_MODULE, APP_SRC, APP_DEST, TOOLS_DIR } from '../../config';
+import { makeTsProject } from '../../utils';
 const plugins = <any>gulpLoadPlugins();
 
 export = () => {

--- a/tools/tasks/seed/build.js.tools.ts
+++ b/tools/tasks/seed/build.js.tools.ts
@@ -1,8 +1,8 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
-import {join} from 'path';
-import {TOOLS_DIR} from '../../config';
-import {templateLocals, makeTsProject} from '../../utils';
+import { join } from 'path';
+import { TOOLS_DIR } from '../../config';
+import { templateLocals, makeTsProject } from '../../utils';
 const plugins = <any>gulpLoadPlugins();
 
 export = () => {

--- a/tools/tasks/seed/check.versions.ts
+++ b/tools/tasks/seed/check.versions.ts
@@ -1,4 +1,4 @@
-import {VERSION_NPM, VERSION_NODE} from '../../config';
+import { VERSION_NPM, VERSION_NODE } from '../../config';
 
 function reportError(message: string) {
   console.error(require('chalk').white.bgRed.bold(message));

--- a/tools/tasks/seed/clean.all.ts
+++ b/tools/tasks/seed/clean.all.ts
@@ -1,4 +1,4 @@
-import {DIST_DIR} from '../../config';
-import {clean} from '../../utils';
+import { DIST_DIR } from '../../config';
+import { clean } from '../../utils';
 
 export = clean(DIST_DIR)

--- a/tools/tasks/seed/clean.dev.ts
+++ b/tools/tasks/seed/clean.dev.ts
@@ -1,4 +1,4 @@
-import {DEV_DEST} from '../../config';
-import {clean} from '../../utils';
+import { DEV_DEST } from '../../config';
+import { clean } from '../../utils';
 
 export = clean(DEV_DEST)

--- a/tools/tasks/seed/clean.prod.ts
+++ b/tools/tasks/seed/clean.prod.ts
@@ -1,4 +1,4 @@
-import {PROD_DEST, TMP_DIR} from '../../config';
-import {clean} from '../../utils';
+import { PROD_DEST, TMP_DIR } from '../../config';
+import { clean } from '../../utils';
 
 export = clean([PROD_DEST, TMP_DIR])

--- a/tools/tasks/seed/clean.tools.ts
+++ b/tools/tasks/seed/clean.tools.ts
@@ -1,9 +1,9 @@
 import * as util from 'gulp-util';
 import * as chalk from 'chalk';
 import * as rimraf from 'rimraf';
-import {readdirSync, lstatSync} from 'fs';
-import {join} from 'path';
-import {TOOLS_DIR} from '../../config';
+import { readdirSync, lstatSync } from 'fs';
+import { join } from 'path';
+import { TOOLS_DIR } from '../../config';
 
 export = (done: any) => {
   deleteAndWalk(TOOLS_DIR);

--- a/tools/tasks/seed/copy.js.prod.ts
+++ b/tools/tasks/seed/copy.js.prod.ts
@@ -1,6 +1,6 @@
 import * as gulp from 'gulp';
-import {join} from 'path';
-import {APP_SRC, TMP_DIR} from '../../config';
+import { join } from 'path';
+import { APP_SRC, TMP_DIR } from '../../config';
 
 export = () => {
   return gulp.src([

--- a/tools/tasks/seed/css-lint.ts
+++ b/tools/tasks/seed/css-lint.ts
@@ -5,8 +5,8 @@ import * as reporter from 'postcss-reporter';
 import * as stylelint from 'stylelint';
 import * as doiuse from 'doiuse';
 import * as colorguard from 'colorguard';
-import {join} from 'path';
-import {APP_SRC, APP_ASSETS, BROWSER_LIST, CSS_SRC, ENV} from '../../config';
+import { join } from 'path';
+import { APP_SRC, APP_ASSETS, BROWSER_LIST, CSS_SRC, ENV } from '../../config';
 const plugins = <any>gulpLoadPlugins();
 
 const isProd = ENV === 'prod';

--- a/tools/tasks/seed/generate.manifest.ts
+++ b/tools/tasks/seed/generate.manifest.ts
@@ -1,5 +1,5 @@
 import * as gulp from 'gulp';
-import {APP_DEST} from '../../config';
+import { APP_DEST } from '../../config';
 
 export = () => {
   return require('angular2-service-worker')

--- a/tools/tasks/seed/karma.start.ts
+++ b/tools/tasks/seed/karma.start.ts
@@ -1,5 +1,5 @@
 import * as karma from 'karma';
-import {join} from 'path';
+import { join } from 'path';
 
 export = (done: any) => {
   new (<any>karma).Server({

--- a/tools/tasks/seed/serve.coverage.ts
+++ b/tools/tasks/seed/serve.coverage.ts
@@ -1,3 +1,3 @@
-import {serveCoverage} from '../../utils';
+import { serveCoverage } from '../../utils';
 
 export = serveCoverage

--- a/tools/tasks/seed/serve.docs.ts
+++ b/tools/tasks/seed/serve.docs.ts
@@ -1,3 +1,3 @@
-import {serveDocs} from '../../utils';
+import { serveDocs } from '../../utils';
 
 export = serveDocs

--- a/tools/tasks/seed/server.prod.ts
+++ b/tools/tasks/seed/server.prod.ts
@@ -1,3 +1,3 @@
-import {serveProd} from '../../utils';
+import { serveProd } from '../../utils';
 
 export = serveProd

--- a/tools/tasks/seed/server.start.ts
+++ b/tools/tasks/seed/server.start.ts
@@ -1,3 +1,3 @@
-import {serveSPA} from '../../utils';
+import { serveSPA } from '../../utils';
 
 export = serveSPA

--- a/tools/tasks/seed/tslint.ts
+++ b/tools/tasks/seed/tslint.ts
@@ -1,7 +1,7 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
-import {join} from 'path';
-import {APP_SRC, TOOLS_DIR, CODELYZER_RULES} from '../../config';
+import { join } from 'path';
+import { APP_SRC, TOOLS_DIR, CODELYZER_RULES } from '../../config';
 const plugins = <any>gulpLoadPlugins();
 
 export = () => {

--- a/tools/tasks/seed/watch.dev.ts
+++ b/tools/tasks/seed/watch.dev.ts
@@ -1,3 +1,3 @@
-import {watch} from '../../utils';
+import { watch } from '../../utils';
 
 export = watch('build.dev')

--- a/tools/tasks/seed/watch.e2e.ts
+++ b/tools/tasks/seed/watch.e2e.ts
@@ -1,3 +1,3 @@
-import {watch} from '../../utils';
+import { watch } from '../../utils';
 
 export = watch('build.e2e')

--- a/tools/tasks/seed/watch.test.ts
+++ b/tools/tasks/seed/watch.test.ts
@@ -1,3 +1,3 @@
-import {watch} from '../../utils';
+import { watch } from '../../utils';
 
 export = watch('build.test')

--- a/tools/utils/seed/code_change_tools.ts
+++ b/tools/utils/seed/code_change_tools.ts
@@ -1,4 +1,4 @@
-import {BROWSER_SYNC_CONFIG} from '../../config';
+import { BROWSER_SYNC_CONFIG } from '../../config';
 import * as browserSync from 'browser-sync';
 import * as path from 'path';
 

--- a/tools/utils/seed/server.ts
+++ b/tools/utils/seed/server.ts
@@ -3,8 +3,8 @@ import * as fallback from 'express-history-api-fallback';
 import * as openResource from 'open';
 import * as serveStatic from 'serve-static';
 import * as codeChangeTool from './code_change_tools';
-import {resolve} from 'path';
-import {APP_BASE, PROD_DEST, PORT, DOCS_DEST, DOCS_PORT, COVERAGE_PORT} from '../../config';
+import { resolve } from 'path';
+import { APP_BASE, PROD_DEST, PORT, DOCS_DEST, DOCS_PORT, COVERAGE_PORT } from '../../config';
 
 
 export function serveSPA() {

--- a/tools/utils/seed/tasks_tools.ts
+++ b/tools/utils/seed/tasks_tools.ts
@@ -3,8 +3,8 @@ import * as util from 'gulp-util';
 import * as chalk from 'chalk';
 import * as isstream from 'isstream';
 import * as tildify from 'tildify';
-import {readdirSync, existsSync, lstatSync} from 'fs';
-import {join} from 'path';
+import { readdirSync, existsSync, lstatSync } from 'fs';
+import { join } from 'path';
 
 
 export function loadTasks(path: string): void {

--- a/tools/utils/seed/watch.ts
+++ b/tools/utils/seed/watch.ts
@@ -1,8 +1,8 @@
 import * as runSequence from 'run-sequence';
-import {notifyLiveReload} from '../../utils';
+import { notifyLiveReload } from '../../utils';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
-import {join} from 'path';
-import {APP_SRC,TEMP_FILES} from '../../config';
+import { join } from 'path';
+import { APP_SRC,TEMP_FILES } from '../../config';
 const plugins = <any>gulpLoadPlugins();
 
 export function watch(taskname: string) {


### PR DESCRIPTION
This PR include simple changes to follow style guide **03-05**.
>https://angular.io/docs/ts/latest/guide/style-guide.html
### Import Destructuring Spacing
**Style 03-05**
**Do** leave one whitespace character inside of the import statements' curly braces when destructuring.
**Why?** Whitespace makes it easier to read the imports.