### PR TITLE
Apply Styleguide Rule `Style 03-06`

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -1,7 +1,9 @@
 import * as gulp from 'gulp';
 import * as runSequence from 'run-sequence';
+
+import { PROJECT_TASKS_DIR, SEED_TASKS_DIR } from './tools/config';
 import { loadTasks } from './tools/utils';
-import { SEED_TASKS_DIR, PROJECT_TASKS_DIR } from './tools/config';
+
 
 loadTasks(SEED_TASKS_DIR);
 loadTasks(PROJECT_TASKS_DIR);

--- a/src/client/app/+about/components/about.component.spec.ts
+++ b/src/client/app/+about/components/about.component.spec.ts
@@ -1,12 +1,13 @@
+import { TestComponentBuilder } from '@angular/compiler/testing';
+import { Component } from '@angular/core';
 import {
   describe,
   expect,
   inject,
   it
 } from '@angular/core/testing';
-import { TestComponentBuilder } from '@angular/compiler/testing';
-import { Component } from '@angular/core';
 import { getDOM } from '@angular/platform-browser/src/dom/dom_adapter';
+
 import { AboutComponent } from './about.component';
 
 export function main() {

--- a/src/client/app/+home/components/home.component.spec.ts
+++ b/src/client/app/+home/components/home.component.spec.ts
@@ -1,14 +1,15 @@
+import { TestComponentBuilder } from '@angular/compiler/testing';
+import { Component } from '@angular/core';
 import {
   describe,
   expect,
-  it,
-  inject
+  inject,
+  it
 } from '@angular/core/testing';
-import { TestComponentBuilder } from '@angular/compiler/testing';
-import { Component } from '@angular/core';
 import { getDOM } from '@angular/platform-browser/src/dom/dom_adapter';
-import { HomeComponent } from './home.component';
+
 import { NameListService } from '../../shared/index';
+import { HomeComponent } from './home.component';
 
 export function main() {
   describe('Home component', () => {

--- a/src/client/app/+home/components/home.component.ts
+++ b/src/client/app/+home/components/home.component.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
 import { FORM_DIRECTIVES } from '@angular/common';
+import { Component } from '@angular/core';
 
 import { NameListService } from '../../shared/index';
 

--- a/src/client/app/components/app.component.spec.ts
+++ b/src/client/app/components/app.component.spec.ts
@@ -1,14 +1,13 @@
+import { TestComponentBuilder } from '@angular/compiler/testing';
+import { Component } from '@angular/core';
 import {
+  async,
+  beforeEachProviders,
   describe,
   expect,
   inject,
-  it,
-  async,
-  beforeEachProviders
+  it
 } from '@angular/core/testing';
-import { TestComponentBuilder } from '@angular/compiler/testing';
-import { Component } from '@angular/core';
-
 import { ROUTER_FAKE_PROVIDERS } from '@angular/router/testing';
 
 import { AppComponent } from './app.component';

--- a/src/client/app/components/app.component.ts
+++ b/src/client/app/components/app.component.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { ROUTER_DIRECTIVES, Routes } from '@angular/router';
+
+import { AboutComponent } from '../+about/index';
+import { HomeComponent } from '../+home/index';
+import { NameListService } from '../shared/index';
 import { NavbarComponent } from './navbar.component';
 import { ToolbarComponent } from './toolbar.component';
-import { NameListService } from '../shared/index';
-import { HomeComponent } from '../+home/index';
-import { AboutComponent } from '../+about/index';
 
 @Component({
   selector: 'sd-app',

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -1,7 +1,8 @@
 import { provide, enableProdMode } from '@angular/core';
+import { APP_BASE_HREF } from '@angular/common';
 import { bootstrap } from '@angular/platform-browser-dynamic';
 import { ROUTER_PROVIDERS } from '@angular/router';
-import { APP_BASE_HREF } from '@angular/common';
+
 import { AppComponent } from './app/components/app.component';
 
 if ('<%= ENV %>' === 'prod') { enableProdMode(); }

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -1,5 +1,5 @@
-import { provide, enableProdMode } from '@angular/core';
 import { APP_BASE_HREF } from '@angular/common';
+import { enableProdMode, provide } from '@angular/core';
 import { bootstrap } from '@angular/platform-browser-dynamic';
 import { ROUTER_PROVIDERS } from '@angular/router';
 

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+
 import { SeedConfig } from './seed.config';
 import { InjectableDependency } from './seed.config.interfaces';
 

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -1,6 +1,7 @@
-import { argv } from 'yargs';
 import { join } from 'path';
-import { InjectableDependency, Environments } from './seed.config.interfaces';
+import { argv } from 'yargs';
+
+import { Environments, InjectableDependency } from './seed.config.interfaces';
 
 export const ENVIRONMENTS: Environments = {
   DEVELOPMENT: 'dev',

--- a/tools/debug.ts
+++ b/tools/debug.ts
@@ -1,5 +1,5 @@
-import { argv } from 'yargs';
 import * as gulp from 'gulp';
+import { argv } from 'yargs';
 
 require('../gulpfile');
 

--- a/tools/tasks/project/sample.task.ts
+++ b/tools/tasks/project/sample.task.ts
@@ -1,6 +1,7 @@
 import * as gulp from 'gulp';
 import { join } from 'path';
-import { APP_SRC, APP_DEST } from '../../config';
+
+import { APP_DEST, APP_SRC } from '../../config';
 
 /**
  * Sample tasks
@@ -10,4 +11,4 @@ import { APP_SRC, APP_DEST } from '../../config';
 export = () => {
   return gulp.src(join(APP_SRC, '**/*.ts'))
     .pipe(gulp.dest(APP_DEST));
-}
+};

--- a/tools/tasks/seed/build.assets.dev.ts
+++ b/tools/tasks/seed/build.assets.dev.ts
@@ -1,13 +1,14 @@
 import * as gulp from 'gulp';
 import { join } from 'path';
-import { APP_SRC, APP_DEST, TEMP_FILES } from '../../config';
+
+import { APP_DEST, APP_SRC, TEMP_FILES } from '../../config';
 
 export = () => {
-  let paths:string[]=[
+  let paths: string[] = [
     join(APP_SRC, '**'),
     '!' + join(APP_SRC, '**', '*.ts')
-  ].concat(TEMP_FILES.map((p) => { return '!'+p; }));
+  ].concat(TEMP_FILES.map((p) => { return '!' + p; }));
 
   return gulp.src(paths)
     .pipe(gulp.dest(APP_DEST));
-}
+};

--- a/tools/tasks/seed/build.assets.prod.ts
+++ b/tools/tasks/seed/build.assets.prod.ts
@@ -1,6 +1,7 @@
 import * as gulp from 'gulp';
 import { join } from 'path';
-import { APP_SRC, APP_DEST, ASSETS_SRC, TEMP_FILES } from '../../config';
+
+import { APP_DEST, APP_SRC, ASSETS_SRC, TEMP_FILES } from '../../config';
 
 // TODO There should be more elegant to prevent empty directories from copying
 let es: any = require('event-stream');
@@ -16,12 +17,12 @@ var onlyDirs = function (es: any) {
 
 export = () => {
   return gulp.src([
-      join(APP_SRC, '**'),
-      '!' + join(APP_SRC, '**', '*.ts'),
-      '!' + join(APP_SRC, '**', '*.css'),
-      '!' + join(APP_SRC, '**', '*.html'),
-      '!' + join(ASSETS_SRC, '**', '*.js')
-    ].concat(TEMP_FILES.map((p) => { return '!'+p; })))
+    join(APP_SRC, '**'),
+    '!' + join(APP_SRC, '**', '*.ts'),
+    '!' + join(APP_SRC, '**', '*.css'),
+    '!' + join(APP_SRC, '**', '*.html'),
+    '!' + join(ASSETS_SRC, '**', '*.js')
+  ].concat(TEMP_FILES.map((p) => { return '!' + p; })))
     .pipe(onlyDirs(es))
     .pipe(gulp.dest(APP_DEST));
-}
+};

--- a/tools/tasks/seed/build.bundles.app.ts
+++ b/tools/tasks/seed/build.bundles.app.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import * as Builder from 'systemjs-builder';
+
 import {
   BOOTSTRAP_MODULE,
   JS_PROD_APP_BUNDLE,

--- a/tools/tasks/seed/build.bundles.ts
+++ b/tools/tasks/seed/build.bundles.ts
@@ -1,7 +1,9 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import * as merge from 'merge-stream';
-import { DEPENDENCIES, JS_PROD_SHIMS_BUNDLE, JS_DEST } from '../../config';
+
+import { DEPENDENCIES, JS_DEST, JS_PROD_SHIMS_BUNDLE } from '../../config';
+
 const plugins = <any>gulpLoadPlugins();
 
 export = () => merge(bundleShims());

--- a/tools/tasks/seed/build.docs.ts
+++ b/tools/tasks/seed/build.docs.ts
@@ -1,7 +1,9 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join } from 'path';
+
 import { APP_SRC, APP_TITLE, DOCS_DEST } from '../../config';
+
 const plugins = <any>gulpLoadPlugins();
 
 export = () => {
@@ -22,10 +24,10 @@ export = () => {
       includeDeclarations: true,
       // Output options (see typedoc docs)
       out: DOCS_DEST,
-      json: join(DOCS_DEST , 'data/docs.json' ),
+      json: join(DOCS_DEST, 'data/docs.json'),
       name: APP_TITLE,
       ignoreCompilerErrors: false,
       experimentalDecorators: true,
       version: true
     }));
-}
+};

--- a/tools/tasks/seed/build.html_css.ts
+++ b/tools/tasks/seed/build.html_css.ts
@@ -1,10 +1,12 @@
+import * as autoprefixer from 'autoprefixer';
+import * as cssnano from 'cssnano';
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import * as merge from 'merge-stream';
-import * as autoprefixer from 'autoprefixer';
-import * as cssnano from 'cssnano';
 import { join } from 'path';
-import { APP_SRC, TMP_DIR, CSS_PROD_BUNDLE, CSS_DEST, APP_DEST, BROWSER_LIST, ENV, DEPENDENCIES } from '../../config';
+
+import { APP_DEST, APP_SRC, BROWSER_LIST, CSS_DEST, CSS_PROD_BUNDLE, DEPENDENCIES, ENV, TMP_DIR } from '../../config';
+
 const plugins = <any>gulpLoadPlugins();
 let cleanCss = require('gulp-clean-css');
 
@@ -51,6 +53,5 @@ function processExternalCss() {
 function getExternalCss() {
   return DEPENDENCIES.filter(d => /\.css$/.test(d.src));
 }
-
 
 export = () => merge(processComponentCss(), prepareTemplates(), processExternalCss());

--- a/tools/tasks/seed/build.index.dev.ts
+++ b/tools/tasks/seed/build.index.dev.ts
@@ -2,8 +2,10 @@ import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join } from 'path';
 import * as slash from 'slash';
-import { APP_SRC, APP_DEST, APP_BASE, DEPENDENCIES } from '../../config';
+
+import { APP_BASE, APP_DEST, APP_SRC, DEPENDENCIES } from '../../config';
 import { templateLocals } from '../../utils';
+
 const plugins = <any>gulpLoadPlugins();
 
 export = () => {
@@ -14,7 +16,6 @@ export = () => {
     .pipe(plugins.template(templateLocals()))
     .pipe(gulp.dest(APP_DEST));
 };
-
 
 function inject(name?: string) {
   return plugins.inject(gulp.src(getInjectablesDependenciesRef(name), { read: false }), {

--- a/tools/tasks/seed/build.index.prod.ts
+++ b/tools/tasks/seed/build.index.prod.ts
@@ -2,17 +2,19 @@ import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join, sep, normalize } from 'path';
 import * as slash from 'slash';
-import { templateLocals } from '../../utils';
+
 import {
   APP_BASE,
-  APP_SRC,
   APP_DEST,
+  APP_SRC,
   CSS_DEST,
-  JS_DEST,
   CSS_PROD_BUNDLE,
+  JS_DEST,
   JS_PROD_APP_BUNDLE,
   JS_PROD_SHIMS_BUNDLE
 } from '../../config';
+import { templateLocals } from '../../utils';
+
 const plugins = <any>gulpLoadPlugins();
 
 export = () => {
@@ -21,7 +23,7 @@ export = () => {
     .pipe(injectCss())
     .pipe(plugins.template(templateLocals()))
     .pipe(gulp.dest(APP_DEST));
-}
+};
 
 function inject(...files: Array<string>) {
     return plugins.inject(gulp.src(files, { read: false }), {

--- a/tools/tasks/seed/build.js.dev.ts
+++ b/tools/tasks/seed/build.js.dev.ts
@@ -2,8 +2,10 @@ import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import * as merge from 'merge-stream';
 import { join } from 'path';
-import { APP_SRC, APP_DEST, TOOLS_DIR } from '../../config';
-import { templateLocals, makeTsProject } from '../../utils';
+
+import { APP_DEST, APP_SRC, TOOLS_DIR } from '../../config';
+import { makeTsProject, templateLocals } from '../../utils';
+
 const plugins = <any>gulpLoadPlugins();
 
 export = () => {
@@ -23,7 +25,6 @@ export = () => {
     .pipe(plugins.plumber())
     .pipe(plugins.sourcemaps.init())
     .pipe(plugins.typescript(tsProject));
-
 
   return result.js
     .pipe(plugins.sourcemaps.write())

--- a/tools/tasks/seed/build.js.e2e.ts
+++ b/tools/tasks/seed/build.js.e2e.ts
@@ -1,10 +1,11 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join } from 'path';
-import { APP_SRC, APP_DEST, TOOLS_DIR } from '../../config';
-import { templateLocals, makeTsProject } from '../../utils';
-const plugins = <any>gulpLoadPlugins();
 
+import { APP_DEST, APP_SRC, TOOLS_DIR } from '../../config';
+import { makeTsProject, templateLocals } from '../../utils';
+
+const plugins = <any>gulpLoadPlugins();
 
 export = () => {
   let tsProject = makeTsProject();
@@ -23,4 +24,4 @@ export = () => {
     .pipe(plugins.sourcemaps.write())
     .pipe(plugins.template(templateLocals()))
     .pipe(gulp.dest(APP_DEST));
-}
+};

--- a/tools/tasks/seed/build.js.prod.ts
+++ b/tools/tasks/seed/build.js.prod.ts
@@ -1,8 +1,10 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join } from 'path';
+
 import { TMP_DIR, TOOLS_DIR } from '../../config';
-import { templateLocals, makeTsProject } from '../../utils';
+import { makeTsProject, templateLocals } from '../../utils';
+
 const plugins = <any>gulpLoadPlugins();
 
 const INLINE_OPTIONS = {
@@ -26,4 +28,4 @@ export = () => {
   return result.js
     .pipe(plugins.template(templateLocals()))
     .pipe(gulp.dest(TMP_DIR));
-}
+};

--- a/tools/tasks/seed/build.js.test.ts
+++ b/tools/tasks/seed/build.js.test.ts
@@ -1,8 +1,10 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
-import { join } from 'path';
-import { BOOTSTRAP_MODULE, APP_SRC, APP_DEST, TOOLS_DIR } from '../../config';
+import { join} from 'path';
+
+import { APP_DEST, APP_SRC, BOOTSTRAP_MODULE, TOOLS_DIR } from '../../config';
 import { makeTsProject } from '../../utils';
+
 const plugins = <any>gulpLoadPlugins();
 
 export = () => {
@@ -26,4 +28,4 @@ export = () => {
   return result.js
     .pipe(plugins.sourcemaps.write())
     .pipe(gulp.dest(APP_DEST));
-}
+};

--- a/tools/tasks/seed/build.js.tools.ts
+++ b/tools/tasks/seed/build.js.tools.ts
@@ -1,8 +1,10 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join } from 'path';
+
 import { TOOLS_DIR } from '../../config';
-import { templateLocals, makeTsProject } from '../../utils';
+import { makeTsProject, templateLocals,  } from '../../utils';
+
 const plugins = <any>gulpLoadPlugins();
 
 export = () => {
@@ -12,7 +14,7 @@ export = () => {
     TOOLS_DIR + '/manual_typings/**/*.d.ts',
     join(TOOLS_DIR, '**/*.ts')
   ];
-  let result = gulp.src(src, {base: './'})
+  let result = gulp.src(src, { base: './' })
     .pipe(plugins.plumber())
     .pipe(plugins.sourcemaps.init())
     .pipe(plugins.typescript(tsProject));
@@ -21,4 +23,4 @@ export = () => {
     .pipe(plugins.sourcemaps.write())
     .pipe(plugins.template(templateLocals()))
     .pipe(gulp.dest('./'));
-}
+};

--- a/tools/tasks/seed/check.versions.ts
+++ b/tools/tasks/seed/check.versions.ts
@@ -1,4 +1,4 @@
-import { VERSION_NPM, VERSION_NODE } from '../../config';
+import { VERSION_NODE, VERSION_NPM } from '../../config';
 
 function reportError(message: string) {
   console.error(require('chalk').white.bgRed.bold(message));
@@ -10,7 +10,7 @@ export = () => {
   let semver = require('semver');
 
   exec('npm --version',
-    function (error: Error, stdout: NodeBuffer, stderr: NodeBuffer) {
+    function(error: Error, stdout: NodeBuffer, stderr: NodeBuffer) {
       if (error !== null) {
         reportError('npm preinstall error: ' + error + stderr);
       }
@@ -21,7 +21,7 @@ export = () => {
     });
 
   exec('node --version',
-    function (error: Error, stdout: NodeBuffer, stderr: NodeBuffer) {
+    function(error: Error, stdout: NodeBuffer, stderr: NodeBuffer) {
       if (error !== null) {
         reportError('npm preinstall error: ' + error + stderr);
       }
@@ -30,4 +30,4 @@ export = () => {
         reportError('NODE is not in required version! Required is ' + VERSION_NODE + ' and you\'re using ' + stdout);
       }
     });
-}
+};

--- a/tools/tasks/seed/clean.all.ts
+++ b/tools/tasks/seed/clean.all.ts
@@ -1,4 +1,4 @@
 import { DIST_DIR } from '../../config';
 import { clean } from '../../utils';
 
-export = clean(DIST_DIR)
+export = clean(DIST_DIR);

--- a/tools/tasks/seed/clean.dev.ts
+++ b/tools/tasks/seed/clean.dev.ts
@@ -1,4 +1,4 @@
 import { DEV_DEST } from '../../config';
 import { clean } from '../../utils';
 
-export = clean(DEV_DEST)
+export = clean(DEV_DEST);

--- a/tools/tasks/seed/clean.prod.ts
+++ b/tools/tasks/seed/clean.prod.ts
@@ -1,4 +1,4 @@
 import { PROD_DEST, TMP_DIR } from '../../config';
 import { clean } from '../../utils';
 
-export = clean([PROD_DEST, TMP_DIR])
+export = clean([PROD_DEST, TMP_DIR]);

--- a/tools/tasks/seed/clean.tools.ts
+++ b/tools/tasks/seed/clean.tools.ts
@@ -1,14 +1,15 @@
-import * as util from 'gulp-util';
 import * as chalk from 'chalk';
+import { lstatSync, readdirSync } from 'fs';
+import * as util from 'gulp-util';
 import * as rimraf from 'rimraf';
-import { readdirSync, lstatSync } from 'fs';
 import { join } from 'path';
+
 import { TOOLS_DIR } from '../../config';
 
 export = (done: any) => {
   deleteAndWalk(TOOLS_DIR);
   done();
-}
+};
 
 function walk(path: any) {
   let files = readdirSync(path);

--- a/tools/tasks/seed/copy.js.prod.ts
+++ b/tools/tasks/seed/copy.js.prod.ts
@@ -1,5 +1,6 @@
 import * as gulp from 'gulp';
 import { join } from 'path';
+
 import { APP_SRC, TMP_DIR } from '../../config';
 
 export = () => {

--- a/tools/tasks/seed/css-lint.ts
+++ b/tools/tasks/seed/css-lint.ts
@@ -1,12 +1,14 @@
+import * as colorguard from 'colorguard';
+import * as doiuse from 'doiuse';
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import * as merge from 'merge-stream';
 import * as reporter from 'postcss-reporter';
 import * as stylelint from 'stylelint';
-import * as doiuse from 'doiuse';
-import * as colorguard from 'colorguard';
-import { join } from 'path';
-import { APP_SRC, APP_ASSETS, BROWSER_LIST, CSS_SRC, ENV } from '../../config';
+import { join} from 'path';
+
+import { APP_ASSETS, APP_SRC, BROWSER_LIST, CSS_SRC, ENV } from '../../config';
+
 const plugins = <any>gulpLoadPlugins();
 
 const isProd = ENV === 'prod';
@@ -38,6 +40,5 @@ function lintExternalCss() {
 function getExternalCss() {
   return APP_ASSETS.filter(d => /\.css$/.test(d.src) && !d.vendor);
 }
-
 
 export = () => merge(lintComponentCss(), lintExternalCss());

--- a/tools/tasks/seed/e2e.ts
+++ b/tools/tasks/seed/e2e.ts
@@ -1,5 +1,5 @@
-import * as gulp from 'gulp';
 import * as express from 'express';
+import * as gulp from 'gulp';
 import { protractor } from 'gulp-protractor';
 
 class Protractor {

--- a/tools/tasks/seed/generate.manifest.ts
+++ b/tools/tasks/seed/generate.manifest.ts
@@ -1,4 +1,5 @@
 import * as gulp from 'gulp';
+
 import { APP_DEST } from '../../config';
 
 export = () => {
@@ -14,4 +15,3 @@ export = () => {
     })
     .pipe(gulp.dest(APP_DEST));
 };
-

--- a/tools/tasks/seed/karma.start.ts
+++ b/tools/tasks/seed/karma.start.ts
@@ -6,4 +6,4 @@ export = (done: any) => {
     configFile: join(process.cwd(), 'karma.conf.js'),
     singleRun: true
   }).start(done);
-}
+};

--- a/tools/tasks/seed/serve.coverage.ts
+++ b/tools/tasks/seed/serve.coverage.ts
@@ -1,3 +1,3 @@
 import { serveCoverage } from '../../utils';
 
-export = serveCoverage
+export = serveCoverage;

--- a/tools/tasks/seed/serve.docs.ts
+++ b/tools/tasks/seed/serve.docs.ts
@@ -1,3 +1,3 @@
 import { serveDocs } from '../../utils';
 
-export = serveDocs
+export = serveDocs;

--- a/tools/tasks/seed/server.prod.ts
+++ b/tools/tasks/seed/server.prod.ts
@@ -1,3 +1,3 @@
 import { serveProd } from '../../utils';
 
-export = serveProd
+export = serveProd;

--- a/tools/tasks/seed/server.start.ts
+++ b/tools/tasks/seed/server.start.ts
@@ -1,3 +1,3 @@
 import { serveSPA } from '../../utils';
 
-export = serveSPA
+export = serveSPA;

--- a/tools/tasks/seed/tslint.ts
+++ b/tools/tasks/seed/tslint.ts
@@ -1,7 +1,9 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join } from 'path';
-import { APP_SRC, TOOLS_DIR, CODELYZER_RULES } from '../../config';
+
+import { APP_SRC, CODELYZER_RULES, TOOLS_DIR } from '../../config';
+
 const plugins = <any>gulpLoadPlugins();
 
 export = () => {

--- a/tools/tasks/seed/watch.dev.ts
+++ b/tools/tasks/seed/watch.dev.ts
@@ -1,3 +1,3 @@
 import { watch } from '../../utils';
 
-export = watch('build.dev')
+export = watch('build.dev');

--- a/tools/tasks/seed/watch.e2e.ts
+++ b/tools/tasks/seed/watch.e2e.ts
@@ -1,3 +1,3 @@
 import { watch } from '../../utils';
 
-export = watch('build.e2e')
+export = watch('build.e2e');

--- a/tools/tasks/seed/watch.test.ts
+++ b/tools/tasks/seed/watch.test.ts
@@ -1,3 +1,3 @@
 import { watch } from '../../utils';
 
-export = watch('build.test')
+export = watch('build.test');

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -1,2 +1,2 @@
-export * from './utils/seed.utils';
 export * from './utils/project.utils';
+export * from './utils/seed.utils';

--- a/tools/utils/seed/clean.ts
+++ b/tools/utils/seed/clean.ts
@@ -1,5 +1,5 @@
-import * as util from 'gulp-util';
 import * as chalk from 'chalk';
+import * as util from 'gulp-util';
 import * as rimraf from 'rimraf';
 
 export function clean(paths: string|string[]): (done: () => void) => void {

--- a/tools/utils/seed/code_change_tools.ts
+++ b/tools/utils/seed/code_change_tools.ts
@@ -1,6 +1,7 @@
-import { BROWSER_SYNC_CONFIG } from '../../config';
 import * as browserSync from 'browser-sync';
 import * as path from 'path';
+
+import { BROWSER_SYNC_CONFIG } from '../../config';
 
 let runServer = () => {
   browserSync.init(BROWSER_SYNC_CONFIG);

--- a/tools/utils/seed/server.ts
+++ b/tools/utils/seed/server.ts
@@ -1,10 +1,11 @@
 import * as express from 'express';
 import * as fallback from 'express-history-api-fallback';
 import * as openResource from 'open';
-import * as serveStatic from 'serve-static';
-import * as codeChangeTool from './code_change_tools';
 import { resolve } from 'path';
-import { APP_BASE, PROD_DEST, PORT, DOCS_DEST, DOCS_PORT, COVERAGE_PORT } from '../../config';
+import * as serveStatic from 'serve-static';
+
+import * as codeChangeTool from './code_change_tools';
+import { APP_BASE, COVERAGE_PORT, DOCS_DEST, DOCS_PORT, PORT, PROD_DEST } from '../../config';
 
 
 export function serveSPA() {

--- a/tools/utils/seed/tasks_tools.ts
+++ b/tools/utils/seed/tasks_tools.ts
@@ -1,11 +1,10 @@
+import * as chalk from 'chalk';
+import { existsSync, lstatSync, readdirSync } from 'fs';
 import * as gulp from 'gulp';
 import * as util from 'gulp-util';
-import * as chalk from 'chalk';
 import * as isstream from 'isstream';
-import * as tildify from 'tildify';
-import { readdirSync, existsSync, lstatSync } from 'fs';
 import { join } from 'path';
-
+import * as tildify from 'tildify';
 
 export function loadTasks(path: string): void {
   util.log('Loading tasks folder', chalk.yellow(path));

--- a/tools/utils/seed/tsproject.ts
+++ b/tools/utils/seed/tsproject.ts
@@ -1,4 +1,5 @@
 import * as gulpLoadPlugins from 'gulp-load-plugins';
+
 const plugins = <any>gulpLoadPlugins();
 
 let _tsProject: any;

--- a/tools/utils/seed/watch.ts
+++ b/tools/utils/seed/watch.ts
@@ -1,8 +1,10 @@
-import * as runSequence from 'run-sequence';
-import { notifyLiveReload } from '../../utils';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join } from 'path';
-import { APP_SRC,TEMP_FILES } from '../../config';
+import * as runSequence from 'run-sequence';
+
+import { APP_SRC, TEMP_FILES } from '../../config';
+import { notifyLiveReload } from '../../utils';
+
 const plugins = <any>gulpLoadPlugins();
 
 export function watch(taskname: string) {


### PR DESCRIPTION
Good evening,

In the docs section of angular.io there has been a Styleguide released: https://angular.io/docs/ts/latest/guide/style-guide.html

This commit applies the necessary changes to conform to the rule 'Style 03-06 Import Line Spacing':
-Do leave one empty line between third party imports and imports of code we created.
-Do list import lines alphabetized by the module.
-Do list destructured imported assets alphabetically.
-Why? The empty line makes it easy to read and locate imports.
-Why? Alphabetizing makes it easier to read and locate imports.

Greetings

Dope