### PR TITLE
Apply `moduleId` to @Component annotation

### DIFF
--- a/src/client/app/+about/about.component.ts
+++ b/src/client/app/+about/about.component.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 
 @Component({
+  moduleId: module.id,
   selector: 'sd-about',
-  templateUrl: 'app/+about/about.component.html',
-  styleUrls: ['app/+about/about.component.css']
+  templateUrl: 'about.component.html',
+  styleUrls: ['about.component.css']
 })
 /**
  * This class represents the lazy loaded AboutComponent.

--- a/src/client/app/+home/home.component.ts
+++ b/src/client/app/+home/home.component.ts
@@ -4,9 +4,10 @@ import { Component } from '@angular/core';
 import { NameListService } from '../shared/index';
 
 @Component({
+  moduleId: module.id,
   selector: 'sd-home',
-  templateUrl: 'app/+home/home.component.html',
-  styleUrls: ['app/+home/home.component.css'],
+  templateUrl: 'home.component.html',
+  styleUrls: ['home.component.css'],
   directives: [FORM_DIRECTIVES]
 })
 /**

--- a/src/client/app/app.component.ts
+++ b/src/client/app/app.component.ts
@@ -7,9 +7,10 @@ import { HomeComponent } from './+home/index';
 import { NameListService, NavbarComponent, ToolbarComponent } from './shared/index';
 
 @Component({
+  moduleId: module.id,
   selector: 'sd-app',
   viewProviders: [NameListService, HTTP_PROVIDERS],
-  templateUrl: 'app/app.component.html',
+  templateUrl: 'app.component.html',
   directives: [ROUTER_DIRECTIVES, NavbarComponent, ToolbarComponent]
 })
 @Routes([

--- a/src/client/app/shared/navbar/navbar.component.ts
+++ b/src/client/app/shared/navbar/navbar.component.ts
@@ -2,9 +2,10 @@ import { Component } from '@angular/core';
 import { ROUTER_DIRECTIVES } from '@angular/router';
 
 @Component({
+  moduleId: module.id,
   selector: 'sd-navbar',
-  templateUrl: 'app/shared/navbar/navbar.component.html',
-  styleUrls: ['app/shared/navbar/navbar.component.css'],
+  templateUrl: 'navbar.component.html',
+  styleUrls: ['navbar.component.css'],
   directives: [ROUTER_DIRECTIVES]
 })
 /**

--- a/src/client/app/shared/toolbar/toolbar.component.ts
+++ b/src/client/app/shared/toolbar/toolbar.component.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 
 @Component({
+  moduleId: module.id,
   selector: 'sd-toolbar',
-  templateUrl: 'app/shared/toolbar/toolbar.component.html',
-  styleUrls: ['app/shared/toolbar/toolbar.component.css']
+  templateUrl: 'toolbar.component.html',
+  styleUrls: ['toolbar.component.css']
 })
 /**
  * This class represents the toolbar component.

--- a/tools/tasks/seed/build.js.prod.ts
+++ b/tools/tasks/seed/build.js.prod.ts
@@ -9,7 +9,7 @@ const plugins = <any>gulpLoadPlugins();
 
 const INLINE_OPTIONS = {
   base: TMP_DIR,
-  useRelativePaths: false,
+  useRelativePaths: true,
   removeLineBreaks: true
 };
 

--- a/tools/tasks/seed/build.js.test.ts
+++ b/tools/tasks/seed/build.js.test.ts
@@ -25,7 +25,7 @@ export = () => {
     .pipe(plugins.sourcemaps.init())
     .pipe(plugins.inlineNg2Template({
       base: APP_SRC,
-      useRelativePaths: false
+      useRelativePaths: true
     }))
     .pipe(plugins.typescript(tsProject));
 


### PR DESCRIPTION
Hey again guys, sorry, i had to open a new PR since my local rebase failed. 

This commit sets the `moduleId` property of the @Component annotation to enable
`templateUrl` and `styleUrls` to be only the file name without the
surrounding path.

`$ npm start` and using the app in the browser runs fine so far, however `$ npm test` fails:

```bash
[22:27:52] Plumber found unhandled error:
 Error in plugin 'gulp-inline-ng2-template'
Message:
    ENOENT: no such file or directory, open '/Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/about.component.html'
Details:
    errno: -2
    code: ENOENT
    syscall: open
    path: /Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/about.component.html
    fileName: /Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/app/+about/about.component.ts
[22:27:52] Plumber found unhandled error:
 Error in plugin 'gulp-inline-ng2-template'
Message:
    ENOENT: no such file or directory, open '/Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/home.component.html'
Details:
    errno: -2
    code: ENOENT
    syscall: open
    path: /Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/home.component.html
    fileName: /Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/app/+home/home.component.ts
[22:27:52] Plumber found unhandled error:
 Error in plugin 'gulp-inline-ng2-template'
Message:
    ENOENT: no such file or directory, open '/Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/navbar.component.html'
Details:
    errno: -2
    code: ENOENT
    syscall: open
    path: /Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/navbar.component.html
    fileName: /Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/app/shared/navbar/navbar.component.ts
[22:27:52] Plumber found unhandled error:
 Error in plugin 'gulp-inline-ng2-template'
Message:
    ENOENT: no such file or directory, open '/Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/toolbar.component.html'
Details:
    errno: -2
    code: ENOENT
    syscall: open
    path: /Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/toolbar.component.html
    fileName: /Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/app/shared/toolbar/toolbar.component.ts
[22:27:52] Plumber found unhandled error:
 Error in plugin 'gulp-inline-ng2-template'
Message:
    ENOENT: no such file or directory, open '/Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/app.component.html'
Details:
    errno: -2
    code: ENOENT
    syscall: open
    path: /Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/app.component.html
    fileName: /Users/DonDope/Development/GitHub/TheDonDope/angular2-seed/src/client/app/app.component.ts
[22:27:54] Finished 'build.js.test' after 3.17 s
```

Is there a further update to some configuration (SystemJS, CommonJS, the builder?) neccessary to make it work?

`$ npm run e2e` runs fine though: 

```bash
# DonDope @ DonDope-MacBook in ~/Development/GitHub/TheDonDope/angular2-seed on git:master o [15:42:38]
$ npm run e2e

> angular2-seed@0.0.0 e2e /Users/DonDope/Development/GitHub/TheDonDope/angular2-seed
> protractor

[22:33:27] I/direct - Using ChromeDriver directly...
[22:33:27] I/launcher - Running 1 instances of WebDriver
Spec started
Started

  About
    ✓ should have correct feature heading
.
  Home
    ✓ should have an input
.    ✓ should have a list of computer scientists
.    ✓ should add a name to the list using the form
.
  App
    ✓ should have a title
.    ✓ should have <nav>
.    ✓ should have correct nav text for Home
.    ✓ should have correct nav text for About
.
Executed 8 of 8 specs SUCCESS in 16 secs.



8 specs, 0 failures
Finished in 16.263 seconds
[22:33:45] I/launcher - 0 instance(s) of WebDriver still running
[22:33:45] I/launcher - chrome #01 passed
```
