### PR TITLE
hotfix(devDeps): Fix typings bundle paths in js build files

### DIFF
--- a/tools/tasks/seed/build.js.dev.ts
+++ b/tools/tasks/seed/build.js.dev.ts
@@ -15,7 +15,7 @@ const plugins = <any>gulpLoadPlugins();
 export = () => {
   let tsProject = makeTsProject();
   let typings = gulp.src([
-    'typings/browser.d.ts',
+    'typings/index.d.ts',
     TOOLS_DIR + '/manual_typings/**/*.d.ts'
   ]);
   let src = [

--- a/tools/tasks/seed/build.js.e2e.ts
+++ b/tools/tasks/seed/build.js.e2e.ts
@@ -14,7 +14,7 @@ const plugins = <any>gulpLoadPlugins();
 export = () => {
   let tsProject = makeTsProject();
   let src = [
-    'typings/browser.d.ts',
+    'typings/index.d.ts',
     TOOLS_DIR + '/manual_typings/**/*.d.ts',
     join(APP_SRC, '**/*.ts'),
     '!' + join(APP_SRC, '**/*.spec.ts')

--- a/tools/tasks/seed/build.js.prod.ts
+++ b/tools/tasks/seed/build.js.prod.ts
@@ -20,7 +20,7 @@ const INLINE_OPTIONS = {
 function buildTS() {
   let tsProject = makeTsProject();
   let src = [
-    'typings/browser.d.ts',
+    'typings/index.d.ts',
     TOOLS_DIR + '/manual_typings/**/*.d.ts',
     join(TMP_DIR, '**/*.ts')
   ];

--- a/tools/tasks/seed/build.js.test.ts
+++ b/tools/tasks/seed/build.js.test.ts
@@ -14,7 +14,7 @@ const plugins = <any>gulpLoadPlugins();
 export = () => {
   let tsProject = makeTsProject();
   let src = [
-    'typings/browser.d.ts',
+    'typings/index.d.ts',
     TOOLS_DIR + '/manual_typings/**/*.d.ts',
     join(APP_SRC, '**/*.ts'),
     '!' + join(APP_SRC, '**/*.e2e-spec.ts'),

--- a/tools/tasks/seed/build.js.tools.ts
+++ b/tools/tasks/seed/build.js.tools.ts
@@ -13,7 +13,7 @@ const plugins = <any>gulpLoadPlugins();
 export = () => {
   let tsProject = makeTsProject();
   let src = [
-    'typings/main.d.ts',
+    'typings/index.d.ts',
     TOOLS_DIR + '/manual_typings/**/*.d.ts',
     join(TOOLS_DIR, '**/*.ts')
   ];


### PR DESCRIPTION
Fixes typings bundle references in build tools because I evidently suck at `find` in VSCode

//cc @Shyam-Chen 

Resolves #915 