### PR TITLE
chore(tests): remove 'debugger;' statements

### DIFF
--- a/test-main.js
+++ b/test-main.js
@@ -1,4 +1,3 @@
-debugger;
 if (!Object.hasOwnProperty('name')) {
   Object.defineProperty(Function.prototype, 'name', {
     get: function() {
@@ -73,7 +72,6 @@ Promise.all([
   System.import('@angular/core/testing'),
   System.import('@angular/platform-browser-dynamic/testing')
 ]).then(function (providers) {
-  debugger;
   var testing = providers[0];
   var testingBrowser = providers[1];
 


### PR DESCRIPTION
Removed `debugger;` statements from test-main.js so that browser debugger doesn't break on them.