### PR TITLE
Excluded node_modules' spec files in karma configuration.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -57,6 +57,7 @@ module.exports = function(config) {
 
     // list of files to exclude
     exclude: [
+      'node_modules/**/*spec.js'
     ],
 
 


### PR DESCRIPTION
Karma was including node_modules spec files. This is not what we want, because:
- we should not test the framework,
- tests may fail so would CI or CD processes.