### PR TITLE
feature : configurable lazy loaded modules

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -50,6 +50,7 @@ gulp.task('build.prod', (done: any) =>
               'build.js.prod',
               'build.bundles',
               'build.bundles.app',
+              'build.modules',
               'build.index.prod',
               done));
 

--- a/src/client/app/+about/about.component.e2e-spec.ts
+++ b/src/client/app/+about/about.component.e2e-spec.ts
@@ -2,7 +2,7 @@ describe('About', () => {
 
   beforeEach( () => {
     browser.get('/');
-    element.all(by.css('nav > a')).get(1).click();
+    element.all(by.css('nav > a')).get(2).click();
   });
 
   it('should have correct feature heading', () => {

--- a/src/client/app/app.component.ts
+++ b/src/client/app/app.component.ts
@@ -2,13 +2,15 @@ import { Component } from '@angular/core';
 import { ROUTER_DIRECTIVES, Routes } from '@angular/router';
 import { HTTP_PROVIDERS} from '@angular/http';
 
-import { AboutComponent } from './+about/index';
 import { HomeComponent } from './+home/index';
+import { AboutComponent } from './+about/index';
 import { NameListService, NavbarComponent, ToolbarComponent } from './shared/index';
+import { componentProxyFactory } from './component_proxy_factory';
 
 /**
  * This class represents the main application component. Within the @Routes annotation is the configuration of the
- * applications routes, configuring the paths for the lazy loaded components (HomeComponent, AboutComponent).
+ * applications routes, configuring the paths for the components (HomeComponent, AboutComponent) and the lazy loaded
+ * component (LazyComponent).
  */
 @Component({
   moduleId: module.id,
@@ -25,6 +27,14 @@ import { NameListService, NavbarComponent, ToolbarComponent } from './shared/ind
   {
     path: '/about',
     component: AboutComponent
+  },
+  {
+    path: '/lazy',
+    component: componentProxyFactory({
+      path: 'js/lazy.js',
+      module: 'app/modules/+lazy/lazy.component',
+      provide: m => m.LazyComponent
+    })
   }
 ])
 export class AppComponent {}

--- a/src/client/app/component_proxy_factory.ts
+++ b/src/client/app/component_proxy_factory.ts
@@ -1,0 +1,40 @@
+import {Type, provide, Component, ComponentResolver, ViewContainerRef} from '@angular/core';
+
+export class ComponentProvider {
+  path:string;
+  module:string;
+  provide:{(module:any):any};
+}
+
+export function componentProxyFactory(provider: ComponentProvider): Type {
+  @Component({
+    selector: 'component-proxy',
+    providers: [provide(ComponentProvider, { useValue: provider })],
+    template: ''
+  })
+  class VirtualComponent {
+    constructor(
+      resolver: ComponentResolver,
+      viewContainer: ViewContainerRef,
+      provider:ComponentProvider) {
+
+      if ('<%= ENV %>' === 'prod') {
+        System.import(provider.path)
+          .then(() => {
+            System.import(provider.module).then((m: any) => {
+              resolver.resolveComponent(provider.provide(m)).then((cFactory) => {
+                viewContainer.createComponent(cFactory);
+              });
+            });
+          });
+      } else {
+        System.import(provider.module).then((m: any) => {
+          resolver.resolveComponent(provider.provide(m)).then((cFactory) => {
+            viewContainer.createComponent(cFactory);
+          });
+        });
+      }
+    }
+  }
+  return VirtualComponent;
+}

--- a/src/client/app/modules/+lazy/index.ts
+++ b/src/client/app/modules/+lazy/index.ts
@@ -1,0 +1,5 @@
+/**
+ * This barrel file provides the export for the lazy loaded LazyComponent.
+ */
+export * from './lazy.component';
+

--- a/src/client/app/modules/+lazy/lazy.component.css
+++ b/src/client/app/modules/+lazy/lazy.component.css
@@ -1,0 +1,12 @@
+:host {
+  display: block;
+  padding: 0 16px;
+}
+
+h2 {
+  font-size: 20px;
+  font-weight: 500;
+  letter-spacing: 0.005em;
+  margin-bottom: 0;
+  margin-top: 0.83em;
+}

--- a/src/client/app/modules/+lazy/lazy.component.e2e-spec.ts
+++ b/src/client/app/modules/+lazy/lazy.component.e2e-spec.ts
@@ -1,0 +1,12 @@
+describe('Lazy loaded module', () => {
+
+  beforeEach( () => {
+    browser.get('/');
+    element.all(by.css('nav > a')).get(1).click();
+  });
+
+  it('should have correct heading', () => {
+    expect(element(by.css('sd-lazy h2')).getText()).toEqual('How to configure a lazy module?');
+  });
+
+});

--- a/src/client/app/modules/+lazy/lazy.component.html
+++ b/src/client/app/modules/+lazy/lazy.component.html
@@ -1,0 +1,10 @@
+<p>
+  Modules can be transferred over the network and loaded lazily on demand,
+  allowing a faster startup time for the application.
+<p>
+
+<h2>How to configure a lazy module?</h2>
+<ul>
+  <li>Add an entry in the "ProjectConfig" "LAZY_MODULES" array.</li>
+  <li>Configure the route associated to the lazy module to use the component proxy factory.</li>
+</ul>

--- a/src/client/app/modules/+lazy/lazy.component.spec.ts
+++ b/src/client/app/modules/+lazy/lazy.component.spec.ts
@@ -1,0 +1,34 @@
+import { TestComponentBuilder } from '@angular/compiler/testing';
+import { Component } from '@angular/core';
+import {
+  describe,
+  expect,
+  inject,
+  it
+} from '@angular/core/testing';
+import { getDOM } from '@angular/platform-browser/src/dom/dom_adapter';
+
+import { LazyComponent } from './lazy.component';
+
+export function main() {
+  describe('Lazy component', () => {
+
+
+    it('should work',
+      inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {
+        tcb.createAsync(TestComponent)
+          .then((rootTC: any) => {
+            let lazyDOMEl = rootTC.debugElement.children[0].nativeElement;
+
+	    expect(getDOM().querySelectorAll(lazyDOMEl, 'h2')[0].textContent).toEqual('How to configure a lazy module?');
+          });
+        }));
+    });
+}
+
+@Component({
+  selector: 'test-cmp',
+  directives: [LazyComponent],
+  template: '<sd-lazy></sd-lazy>'
+})
+class TestComponent {}

--- a/src/client/app/modules/+lazy/lazy.component.ts
+++ b/src/client/app/modules/+lazy/lazy.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+/**
+ * This class represents the lazy loaded LazyComponent.
+ */
+@Component({
+  moduleId: module.id,
+  selector: 'sd-lazy',
+  templateUrl: 'lazy.component.html',
+  styleUrls: ['lazy.component.css']
+})
+export class LazyComponent {}

--- a/src/client/app/shared/navbar/navbar.component.html
+++ b/src/client/app/shared/navbar/navbar.component.html
@@ -1,4 +1,5 @@
 <nav>
   <a [routerLink]="['/']">HOME</a>
+  <a [routerLink]="['/lazy']">LAZY MODULE</a>
   <a [routerLink]="['/about']">ABOUT</a>
 </nav>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -40,13 +40,11 @@
   <!-- shims:js -->
   <!-- endinject -->
 
-  <% if (ENV === 'dev') { %>
   <script>
     System.config(<%=
       JSON.stringify(SYSTEM_CONFIG, null, 2)
     %>)
   </script>
-  <% } %>
 
   <!-- libs:js -->
   <!-- endinject -->
@@ -54,7 +52,6 @@
   <!-- inject:js -->
   <!-- endinject -->
 
-  <% if (ENV === 'dev') { %>
   <script>
   System.import('<%= BOOTSTRAP_MODULE %>')
     .catch(function (e) {
@@ -62,7 +59,6 @@
         'Report this error at https://github.com/mgechev/angular2-seed/issues');
     });
   </script>
-  <% } %>
 
 </body>
 </html>

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 
 import { SeedConfig } from './seed.config';
-import { InjectableDependency } from './seed.config.interfaces';
+import {InjectableDependency, LazyModule} from './seed.config.interfaces';
 
 /**
  * This class extends the basic seed configuration, allowing for project specific overrides. A few examples can be found
@@ -10,6 +10,14 @@ import { InjectableDependency } from './seed.config.interfaces';
 export class ProjectConfig extends SeedConfig {
 
   PROJECT_TASKS_DIR = join(process.cwd(), this.TOOLS_DIR, 'tasks', 'project');
+
+  LAZY_MODULES: LazyModule[] = [
+    {
+      src: 'modules/+lazy/index',
+      dest: 'lazy.js'
+    }
+  ];
+
 
   constructor() {
     super();

--- a/tools/config/seed.config.interfaces.ts
+++ b/tools/config/seed.config.interfaces.ts
@@ -11,3 +11,8 @@ export interface Environments {
   [key: string]: string;
 }
 
+export interface LazyModule {
+  src: string;
+  dest: string;
+}
+

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { argv } from 'yargs';
 
-import { Environments, InjectableDependency } from './seed.config.interfaces';
+import {Environments, InjectableDependency} from './seed.config.interfaces';
 
 /**
  * The enumeration of available environments.
@@ -219,6 +219,12 @@ export class SeedConfig {
   JS_PROD_SHIMS_BUNDLE = 'shims.js';
 
   /**
+   * The name of the bundle file to include all external dependencies files.
+   * @type {string}
+     */
+  JS_PROD_DEPENDENCIES_BUNDLE = 'dependencies.js';
+
+  /**
    * The name of the bundle file to include all JavaScript application files.
    * @type {string}
    */
@@ -246,12 +252,12 @@ export class SeedConfig {
    * @type {InjectableDependency[]}
    */
   NPM_DEPENDENCIES: InjectableDependency[] = [
-    { src: 'systemjs/dist/system-polyfills.src.js', inject: 'shims', env: ENVIRONMENTS.DEVELOPMENT },
+    { src: 'systemjs/dist/system-polyfills.src.js', inject: 'shims'},
     { src: 'zone.js/dist/zone.js', inject: 'libs' },
     { src: 'reflect-metadata/Reflect.js', inject: 'shims' },
     { src: 'core-js/client/shim.min.js', inject: 'shims' },
-    { src: 'systemjs/dist/system.src.js', inject: 'shims', env: ENVIRONMENTS.DEVELOPMENT },
-    { src: 'rxjs/bundles/Rx.js', inject: 'libs', env: ENVIRONMENTS.DEVELOPMENT }
+    { src: 'systemjs/dist/system.src.js', inject: 'shims'},
+    { src: 'rxjs/bundles/Rx.js', inject: 'libs'}
   ];
 
   /**
@@ -310,11 +316,22 @@ export class SeedConfig {
   };
 
   /**
+   * The configuration of SystemJS for the runtime `prod` environment.
+   * @type {any}
+   */
+  protected SYSTEM_CONFIG_PROD: any = {
+    defaultJSExtensions: true,
+    packages: {
+      rxjs: { defaultExtension: false }
+    }
+  };
+
+  /**
    * The configuration of SystemJS of the application.
    * Per default, the configuration of the `dev` environment will be used.
    * @type {any}
    */
-  SYSTEM_CONFIG: any = this.SYSTEM_CONFIG_DEV;
+  SYSTEM_CONFIG: any = this.ENV === 'prod' ? this.SYSTEM_CONFIG_PROD : this.SYSTEM_CONFIG_DEV;
 
   /**
    * The system builder configuration of the application.
@@ -327,41 +344,18 @@ export class SeedConfig {
       join(this.PROJECT_ROOT, 'node_modules', '@angular', '*', 'package.json')
     ],
     paths: {
-      [`${this.TMP_DIR}/*`]: `${this.TMP_DIR}/*`,
-      '*': 'node_modules/*'
+      '@angular/core': `node_modules/@angular/core/core.umd.js`,
+      '@angular/common': `node_modules/@angular/common/common.umd.js`,
+      '@angular/compiler': `node_modules/@angular/compiler/compiler.umd.js`,
+      '@angular/http': `node_modules/@angular/http/http.umd.js`,
+      '@angular/router': `node_modules/@angular/router/router.umd.js`,
+      '@angular/platform-browser': `node_modules/@angular/platform-browser/platform-browser.umd.js`,
+      '@angular/platform-browser-dynamic': `node_modules/@angular/platform-browser-dynamic/platform-browser-dynamic.umd.js`,
+      'app/*' : `${this.TMP_DIR}/app/*`,
+      'rxjs/*': `node_modules/rxjs/*`
     },
     packages: {
-      '@angular/core': {
-        main: 'index.js',
-        defaultExtension: 'js'
-      },
-      '@angular/compiler': {
-        main: 'index.js',
-        defaultExtension: 'js'
-      },
-      '@angular/common': {
-        main: 'index.js',
-        defaultExtension: 'js'
-      },
-      '@angular/http': {
-        main: 'index.js',
-        defaultExtension: 'js'
-      },
-      '@angular/platform-browser': {
-        main: 'index.js',
-        defaultExtension: 'js'
-      },
-      '@angular/platform-browser-dynamic': {
-        main: 'index.js',
-        defaultExtension: 'js'
-      },
-      '@angular/router': {
-        main: 'index.js',
-        defaultExtension: 'js'
-      },
-      'rxjs': {
-        defaultExtension: 'js'
-      }
+      rxjs: { defaultExtension: false }
     }
   };
 

--- a/tools/tasks/seed/build.bundles.app.ts
+++ b/tools/tasks/seed/build.bundles.app.ts
@@ -3,6 +3,7 @@ import * as Builder from 'systemjs-builder';
 
 import {
   BOOTSTRAP_MODULE,
+  JS_PROD_DEPENDENCIES_BUNDLE,
   JS_PROD_APP_BUNDLE,
   JS_DEST,
   SYSTEM_BUILDER_CONFIG,
@@ -11,19 +12,24 @@ import {
 
 const BUNDLER_OPTIONS = {
   format: 'cjs',
-  minify: true,
   mangle: false
 };
 
 /**
- * Executes the build process, bundlig the JavaScript files using the SystemJS builder.
+ * Executes the build process, bundling the JavaScript files using the SystemJS builder.
  */
 export = (done: any) => {
+
   let builder = new Builder(SYSTEM_BUILDER_CONFIG);
-  builder
-    .buildStatic(join(TMP_DIR, BOOTSTRAP_MODULE),
-                 join(JS_DEST, JS_PROD_APP_BUNDLE),
-                 BUNDLER_OPTIONS)
-    .then(() => done())
+  builder.bundle(join(TMP_DIR, BOOTSTRAP_MODULE) + ' - [' + join(TMP_DIR, 'app/**/*') + ']',
+    join(JS_DEST, JS_PROD_DEPENDENCIES_BUNDLE), BUNDLER_OPTIONS)
+    .then(() => builder
+      .bundle(join(TMP_DIR, BOOTSTRAP_MODULE) + ' - ' +  join(JS_DEST, JS_PROD_DEPENDENCIES_BUNDLE),
+        join(JS_DEST, JS_PROD_APP_BUNDLE),
+        BUNDLER_OPTIONS)
+      .then(() => done())
+      .catch(err => done(err))
+    )
     .catch(err => done(err));
+
 };

--- a/tools/tasks/seed/build.bundles.app.ts
+++ b/tools/tasks/seed/build.bundles.app.ts
@@ -12,6 +12,7 @@ import {
 
 const BUNDLER_OPTIONS = {
   format: 'cjs',
+  minify: true,
   mangle: false
 };
 

--- a/tools/tasks/seed/build.index.prod.ts
+++ b/tools/tasks/seed/build.index.prod.ts
@@ -11,7 +11,8 @@ import {
   CSS_PROD_BUNDLE,
   JS_DEST,
   JS_PROD_APP_BUNDLE,
-  JS_PROD_SHIMS_BUNDLE
+  JS_PROD_SHIMS_BUNDLE,
+  JS_PROD_DEPENDENCIES_BUNDLE
 } from '../../config';
 import { templateLocals } from '../../utils';
 
@@ -23,19 +24,22 @@ const plugins = <any>gulpLoadPlugins();
  */
 export = () => {
   return gulp.src(join(APP_SRC, 'index.html'))
-    .pipe(injectJs())
+    .pipe(injectJsShim())
+    .pipe(injectJsLibs())
+    .pipe(injectJsApp())
     .pipe(injectCss())
     .pipe(plugins.template(templateLocals()))
     .pipe(gulp.dest(APP_DEST));
 };
 
 /**
- * Injects the given file array and transforms the path of the files.
+ * Injects the given file array into the corresponding inject location and transforms the path of the files.
+ * @param {string} name - The name of the inject location.
  * @param {Array<string>} files - The files to be injected.
  */
-function inject(...files: Array<string>) {
+function inject(name: string, ...files: Array<string>) {
     return plugins.inject(gulp.src(files, { read: false }), {
-        files,
+        name,
         transform: transformPath()
     });
 }
@@ -43,8 +47,16 @@ function inject(...files: Array<string>) {
 /**
  * Injects the bundled JavaScript shims and application bundles for the production environment.
  */
-function injectJs() {
-  return inject(join(JS_DEST, JS_PROD_SHIMS_BUNDLE), join(JS_DEST, JS_PROD_APP_BUNDLE));
+function injectJsShim() {
+  return inject('shims', join(JS_DEST, JS_PROD_SHIMS_BUNDLE));
+}
+
+function injectJsLibs() {
+  return inject('libs', join(JS_DEST, JS_PROD_DEPENDENCIES_BUNDLE));
+}
+
+function injectJsApp() {
+  return inject(null, join(JS_DEST, JS_PROD_APP_BUNDLE));
 }
 
 /**

--- a/tools/tasks/seed/build.modules.ts
+++ b/tools/tasks/seed/build.modules.ts
@@ -1,0 +1,32 @@
+import { join } from 'path';
+import * as Builder from 'systemjs-builder';
+
+import {
+  JS_PROD_DEPENDENCIES_BUNDLE,
+  JS_DEST,
+  SYSTEM_BUILDER_CONFIG,
+  TMP_DIR,
+  LAZY_MODULES
+} from '../../config';
+import {LazyModule} from '../../config/seed.config.interfaces';
+
+const BUNDLER_OPTIONS = {
+  format: 'cjs',
+  mangle: false
+};
+
+/**
+ * Executes the build process, bundling the JavaScript files using the SystemJS builder.
+ */
+export = (done: any) => {
+
+  let builder = new Builder(SYSTEM_BUILDER_CONFIG);
+  Promise.all<any>(LAZY_MODULES.map((module: LazyModule) => buildModule(module, builder)).values()).then(() => done())
+    .catch(err => done(err));
+
+};
+
+function buildModule(lazyModule: LazyModule, builder: Builder) : Promise<any> {
+  return builder.bundle(join(TMP_DIR, 'app', lazyModule.src) + ' - ' +  join(JS_DEST, JS_PROD_DEPENDENCIES_BUNDLE),
+    join(JS_DEST, lazyModule.dest), BUNDLER_OPTIONS);
+}

--- a/tools/tasks/seed/build.modules.ts
+++ b/tools/tasks/seed/build.modules.ts
@@ -12,6 +12,7 @@ import {LazyModule} from '../../config/seed.config.interfaces';
 
 const BUNDLER_OPTIONS = {
   format: 'cjs',
+  minify: true,
   mangle: false
 };
 


### PR DESCRIPTION
- Prod build now uses systemjs at runtime
- Prod build extracts libraries in a separate bundle
- New gulp task : build.modules, it builds the lazy modules that can be  configured in project config
- Lazy modules are loaded through system js and a virtual component configured in the routes

This pull-request is related to improvements proposed here : https://github.com/mgechev/angular2-seed/issues/864