### PR TITLE
[bug fix] observable now only get triggered only once as expected

### DIFF
--- a/src/client/app/shared/name-list/name-list.service.ts
+++ b/src/client/app/shared/name-list/name-list.service.ts
@@ -3,6 +3,7 @@ import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/publishReplay';
 
 /**
  * This class provides the NameList service with methods to read names and add names.
@@ -44,7 +45,7 @@ export class NameListService {
         .map((data: string[]) => {
           this.request = null;
           return this.names = data;
-        });
+        }).publishReplay(1).refCount();
     }
     return this.request;
   }


### PR DESCRIPTION
Observable caching in the name-list service was not working as expected.
For instance, if you put that code in the HomeComponent

```ts
constructor(public nameListService: NameListService) {
    nameListService.get().subscribe((names) => console.log(names));
    nameListService.get().subscribe((names) => console.log(names));
}
```

and inspect the network, you will see the ajax call is triggered twice.

With my fix, it is only called once, as expected.