### PR TITLE
build.prod task now fails on TS error

### DIFF
--- a/tools/tasks/seed/build.js.prod.ts
+++ b/tools/tasks/seed/build.js.prod.ts
@@ -27,7 +27,11 @@ function buildTS() {
   let result = gulp.src(src)
     .pipe(plugins.plumber())
     .pipe(INLINE_TEMPLATES ? plugins.inlineNg2Template(INLINE_OPTIONS) : plugins.util.noop())
-    .pipe(plugins.typescript(tsProject));
+    .pipe(plugins.typescript(tsProject))
+    .once('error', function () {
+      this.once('finish', () => process.exit(1));
+    });
+
 
   return result.js
     .pipe(plugins.template(templateLocals()))


### PR DESCRIPTION
Currently the build.prod will succeed, even when there are TS errors.

I can understand that this is desired behavior on build.dev since the watch would otherwise continuously break. However, to me it makes sense that when running the build.prod it should fail the build. (Since we have the build.prod running in a Jenkins CI)