### PR TITLE
Clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ _Does not rely on any global dependencies._
 - [How to start](#how-to-start)
 - [Table of Content](#table-of-content)
 - [Configuration](#configuration)
+- [Environment Configuration](#environment-configuration)
 - [Tools documentation](#tools-documentation)
 - [How to extend?](#how-to-extend)
 - [Running tests](#running-tests)

--- a/src/client/app/+about/about.routes.ts
+++ b/src/client/app/+about/about.routes.ts
@@ -1,6 +1,8 @@
+import { RouterConfig } from '@angular/router';
+
 import { AboutComponent } from './index';
 
-export const AboutRoutes = [
+export const AboutRoutes: RouterConfig = [
   {
     path: 'about',
     component: AboutComponent

--- a/src/client/app/+home/home.routes.ts
+++ b/src/client/app/+home/home.routes.ts
@@ -1,9 +1,10 @@
+import { RouterConfig } from '@angular/router';
+
 import { HomeComponent } from './index';
 
-export const HomeRoutes = [
+export const HomeRoutes: RouterConfig = [
   {
     path: '',
-    component: HomeComponent,
-    index: true
+    component: HomeComponent
   },
 ];

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -15,24 +15,6 @@
   <sd-app>Loading...</sd-app>
 
   <script>
-  // function.name (all IE)
-  // Remove once https://github.com/angular/angular/issues/6501 is fixed.
-  /*! @source http://stackoverflow.com/questions/6903762/function-name-not-supported-in-ie*/
-  if (!Object.hasOwnProperty('name')) {
-    Object.defineProperty(Function.prototype, 'name', {
-      get: function() {
-        var matches = this.toString().match(/^\s*function\s*((?![0-9])[a-zA-Z0-9_$]*)\s*\(/);
-        var name = matches && matches.length > 1 ? matches[1] : "";
-        // For better performance only parse once, and then cache the
-        // result through a new accessor for repeated access.
-        Object.defineProperty(this, 'name', {value: name});
-        return name;
-      }
-    });
-  }
-  </script>
-
-  <script>
   // Fixes undefined module function in SystemJS bundle
   function module() {}
   </script>

--- a/test-main.js
+++ b/test-main.js
@@ -30,7 +30,7 @@ System.config({
     '@angular': 'node_modules/@angular'
   },
   packages: {
-    '@angular/core': {
+    '@angular/common': {
       main: 'index.js',
       defaultExtension: 'js'
     },
@@ -38,7 +38,7 @@ System.config({
       main: 'index.js',
       defaultExtension: 'js'
     },
-    '@angular/common': {
+    '@angular/core': {
       main: 'index.js',
       defaultExtension: 'js'
     },

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -80,8 +80,8 @@ export class SeedConfig {
 
   /**
    * The flag to include templates into JS app prod file.
-   * Per default the option is `true`, but can it can be set to false using `--inline-template false`
-   * flag when running `npm run build.prod`.
+   * Per default the option is `true`, but can it can be set to false using `--inline-template false` flag when running
+   * `npm run build.prod`.
    * @type {boolean}
    */
   INLINE_TEMPLATES = argv['inline-template'] !== 'false';
@@ -305,14 +305,14 @@ export class SeedConfig {
     ],
     paths: {
       [this.BOOTSTRAP_MODULE]: `${this.APP_BASE}${this.BOOTSTRAP_MODULE}`,
-      '@angular/core': `node_modules/@angular/core/bundles/core.umd.js`,
       '@angular/common': `node_modules/@angular/common/bundles/common.umd.js`,
       '@angular/compiler': `node_modules/@angular/compiler/bundles/compiler.umd.js`,
+      '@angular/core': `node_modules/@angular/core/bundles/core.umd.js`,
       '@angular/forms': `node_modules/@angular/forms/bundles/forms.umd.js`,
       '@angular/http': `node_modules/@angular/http/bundles/http.umd.js`,
-      '@angular/router': `node_modules/@angular/router/index.js`,
       '@angular/platform-browser': `node_modules/@angular/platform-browser/bundles/platform-browser.umd.js`,
       '@angular/platform-browser-dynamic': `node_modules/@angular/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js`,
+      '@angular/router': `node_modules/@angular/router/index.js`,
       'rxjs/*': `node_modules/rxjs/*`,
       'app/*': `/app/*`,
       '*': `node_modules/*`
@@ -344,7 +344,7 @@ export class SeedConfig {
       '*': 'node_modules/*'
     },
     packages: {
-      '@angular/core': {
+      '@angular/common': {
         main: 'index.js',
         defaultExtension: 'js'
       },
@@ -352,7 +352,7 @@ export class SeedConfig {
         main: 'index.js',
         defaultExtension: 'js'
       },
-      '@angular/common': {
+      '@angular/core': {
         main: 'index.js',
         defaultExtension: 'js'
       },


### PR DESCRIPTION
This PR includes some minor clean up actions:

- **Add Environment Configuration to TOC** (Adds a link to the environment configuration to the table of contents.)
- **Reorder angular packages alphabetically** (Reorders the angular packages alphabetically in the `tools/config/seed/seed.config.ts` (SystemJS, System Builder) and `test-main.js` to be in accordance to order in the `package.json`.)
- **Update Route Configuration for lazy loaded components** (Updates the route configuration for the `+about` and `+home` lazy loaded component according to the angular guide (see: https://angular.io/docs/ts/latest/guide/router.html). 
![screenshot 2016-06-24 18 32 46](https://cloud.githubusercontent.com/assets/1188033/16343911/281b0bb4-3a3a-11e6-8aa8-31c85ec79262.png)

Furthermore removes the index property which was deprecated with `@angular/router 3.0.0-alpha.7`. Now, the `path: ''` indicates the index of a route.)
- **Remove workaround for angular upstream issue in index.html** (Removes the workaround present in the index.html that was made because of the angular issue #6501 (https://github.com/angular/angular/issues/6501). For information on the fix, see here: https://github.com/angular/angular/issues/6501#issuecomment-220735527)

Greetings

Dope