### PR TITLE
Clean index.html

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -14,11 +14,6 @@
 
   <sd-app>Loading...</sd-app>
 
-  <script>
-  // Fixes undefined module function in SystemJS bundle
-  function module() {}
-  </script>
-
   <!-- shims:js -->
   <!-- endinject -->
 


### PR DESCRIPTION
Removes the workaround for the undefined module bundle in SystemJS
introduced by
https://github.com/mgechev/angular2-seed/commit/d7b41374b5a54fce90d9ca51e927e42c047f609d.

@ludohenin Do we still need this? I removed it and everything still worked well.