### PR TITLE
fix 'an/a' typo's  

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -75,10 +75,10 @@ The seed provides the following utilities:
 
 | Filename               | Description |
 | :--------------------- | :---------- |
-| `clean.ts`             | Provides an utility to clean files and directories |
+| `clean.ts`             | Provides a utility to clean files and directories |
 | `code_change_tools.ts` | Provides utilites to make use of BrowserSync to refresh the browser after a code change |
 | `server.ts`            | Provides utilites to start `express` servers for the application, the documentation and the unit test coverage |
 | `task_tools.ts`        | Provides utilites to start tasks (matching task names as string input parameters from the `gulpfile.ts` to the corresponding files) |
-| `template_locals.ts`   | Provides an utiltiy for template locals |
-| `tsproject.ts`         | Provides an utility to configure the TypeScript transpilation |
-| `watch.ts`             | Provides an utility to watch for file changes and notify live reloads |
+| `template_locals.ts`   | Provides a utiltiy for template locals |
+| `tsproject.ts`         | Provides a utility to configure the TypeScript transpilation |
+| `watch.ts`             | Provides a utility to watch for file changes and notify live reloads |


### PR DESCRIPTION
I hope you don't mind this extremely trivial PR, it is my first one, so I want to make sure I have the process down before trying anything more substantial.  Here is an [explanation of the change: ](http://www.everythingenglishblog.com/?p=541)

> Also consider words starting with “u.” Some such words make a “y” or consonant sound (e.g., unicorn, unique, and ukulele); in such instances, you should use the article “a” (e.g., a unicorn, a unique store, and a ukulele). 
