### PR TITLE
fix(config): rxjs package's defaultExtension was set to true, but should be js instead

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -309,7 +309,7 @@ export class SeedConfig {
       '*': `node_modules/*`
     },
     packages: {
-      rxjs: { defaultExtension: false }
+      rxjs: { defaultExtension: 'js' }
     }
   };
 


### PR DESCRIPTION
Allows to import certain rxjs operators such as 'timeInterval' and 'exhaustMap'. Fixes https://github.com/mgechev/angular2-seed/issues/973 and https://github.com/mgechev/angular2-seed/issues/784 
