### PR TITLE
fix(1086) silence gulp-inline-ng2-template css warnings

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -59,6 +59,7 @@ gulp.task('build.test', (done: any) =>
   runSequence('clean.dev',
               'tslint',
               'build.assets.dev',
+              'build.html_css',
               'build.js.test',
               'build.index.dev',
               done));

--- a/tools/tasks/seed/build.js.test.ts
+++ b/tools/tasks/seed/build.js.test.ts
@@ -2,7 +2,7 @@ import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join} from 'path';
 
-import { APP_DEST, APP_SRC, BOOTSTRAP_MODULE, TOOLS_DIR } from '../../config';
+import { APP_DEST, APP_SRC, BOOTSTRAP_MODULE, TOOLS_DIR, ENABLE_SCSS } from '../../config';
 import { makeTsProject } from '../../utils';
 
 const plugins = <any>gulpLoadPlugins();
@@ -25,7 +25,8 @@ export = () => {
     .pipe(plugins.sourcemaps.init())
     .pipe(plugins.inlineNg2Template({
       base: APP_SRC,
-      useRelativePaths: true
+      useRelativePaths: true,
+      supportNonExistentFiles: ENABLE_SCSS
     }))
     .pipe(plugins.typescript(tsProject));
 


### PR DESCRIPTION
Related to issue #1086
- Execute build.html_css before build.js.test to satisfy karma
- If using scss, gulp-inline-ng2-template will be unable to find the css files
  it needs. Setting the 'supportNonExistentFiles' boolean to true ignores this warning.