### PR TITLE
Add express compression for Prod and Unit Test Servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "browser-sync": "^2.11.2",
     "codelyzer": "0.0.20",
     "colorguard": "^1.1.1",
+    "compression": "^1.6.2",
     "connect": "^3.4.1",
     "connect-history-api-fallback": "^1.2.0",
     "connect-livereload": "^0.5.3",

--- a/tools/utils/seed/server.ts
+++ b/tools/utils/seed/server.ts
@@ -62,6 +62,8 @@ export function serveCoverage() {
 export function serveProd() {
   let root = resolve(process.cwd(), PROD_DEST);
   let server = express();
+  let compression = require('compression');
+      server.use(compression());
 
   server.use(APP_BASE, serveStatic(root));
 

--- a/tools/utils/seed/server.ts
+++ b/tools/utils/seed/server.ts
@@ -45,6 +45,8 @@ export function serveDocs() {
  */
 export function serveCoverage() {
   let server = express();
+  let compression = require('compression');
+      server.use(compression());
 
   server.use(
     APP_BASE,


### PR DESCRIPTION
Add express compression for `serve.prod`.
I think this make sense, show developers real size of application with gzip compression and loading time. It's very important when you make a visual testing with dev tools and using _throttling_.

Same thing I have add for `unit test` server to speed up unit test run.