### PR TITLE
fine tuned browserSync reload to inject css

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -406,7 +406,7 @@ export class SeedConfig {
       port: this.PORT,
       startPath: this.APP_BASE,
       open: argv['b'] ? false : true,
-      injectChanges: false,
+      injectChanges: true,
       server: {
         baseDir: `${this.DIST_DIR}/empty/`,
         routes: {

--- a/tools/utils/seed/code_change_tools.ts
+++ b/tools/utils/seed/code_change_tools.ts
@@ -2,7 +2,7 @@ import * as browserSync from 'browser-sync';
 // import * as path from 'path';
 
 import { getPluginConfig } from '../../config';
-
+import * as path from 'path';
 /**
  * Initialises BrowserSync with the configuration defined in seed.config.ts (or if overriden: project.config.ts).
  */
@@ -33,20 +33,22 @@ let changed = (files: any) => {
     files = [files];
   }
 
-  //  let onlyStylesChanged =
-  //    files
-  //      .map((f:string) => path.parse(f).ext)
-  //      .reduce((prev:string, current:string) => prev && (current === '.scss' || current === '.css'), true);
+   let onlyStylesChanged =
+     files
+       .map((f:string) => path.parse(f))
+       .reduce((prev:boolean, current:path.ParsedPath) => {       
+         return prev && (current.ext === '.scss' || current.ext === '.css') && !current.name.endsWith(".component")
+        }, true);
   //
   // if (ENABLE_HOT_LOADING) {
   //   ng2HotLoader.onChange(files);
   // } else {
   //TODO: Figure out why you can't pass a file to reload
-  // if (onlyStylesChanged === false) {
-    browserSync.reload(files);
-  // } else {
-  //   browserSync.reload('*.css');
-  // }
+  if (onlyStylesChanged === false) {
+    browserSync.reload();
+  } else {
+    browserSync.reload('**/*.css');
+  }
   //}
 };
 


### PR DESCRIPTION
Hi,
Instead of a full reload, browserSync now inject the css files.
But when the css ends with *.component* a full reload is performed, issues with shadow dom I suppose.

Tested with both css and sass

Another way to look at it, is that global css changes in main.css or main.sass get inject, component css get reloaded.

That improve dev experience a little bit.

Another good thing to do, is modify the watch task to not recompile typescript  on each file change, that way the performance is improved.