### PR TITLE
Feature/typeless compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "gulp-sourcemaps": "2.0.0-alpha",
     "gulp-template": "^4.0.0",
     "gulp-tslint": "^4.3.3",
-    "gulp-typescript": "~2.13.4",
+    "gulp-typescript": "~2.13.6",
     "gulp-uglify": "^1.5.3",
     "gulp-util": "^3.0.7",
     "gulp-watch": "^4.3.5",

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -13,6 +13,9 @@ export class ProjectConfig extends SeedConfig {
   constructor() {
     super();
     // this.APP_TITLE = 'Put name of your app here';
+    
+    /* Enable typeless compiler runs (faster) between typed compiler runs. */
+    this.TYPED_COMPILE_INTERVAL = 3;
 
     // Add `NPM` third-party libraries to be injected/bundled.
     this.NPM_DEPENDENCIES = [
@@ -29,7 +32,7 @@ export class ProjectConfig extends SeedConfig {
     ];
 
     /* Add to or override NPM module configurations: */
-    //this.mergeObject(this.PLUGIN_CONFIGS['browser-sync'], { ghostMode: false });
+    // this.mergeObject(this.PLUGIN_CONFIGS['browser-sync'], { ghostMode: false });
   }
 
 }

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -15,7 +15,7 @@ export class ProjectConfig extends SeedConfig {
     // this.APP_TITLE = 'Put name of your app here';
     
     /* Enable typeless compiler runs (faster) between typed compiler runs. */
-    this.TYPED_COMPILE_INTERVAL = 3;
+    // this.TYPED_COMPILE_INTERVAL = 5;
 
     // Add `NPM` third-party libraries to be injected/bundled.
     this.NPM_DEPENDENCIES = [

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -13,7 +13,7 @@ export class ProjectConfig extends SeedConfig {
   constructor() {
     super();
     // this.APP_TITLE = 'Put name of your app here';
-    
+
     /* Enable typeless compiler runs (faster) between typed compiler runs. */
     // this.TYPED_COMPILE_INTERVAL = 5;
 

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -91,7 +91,7 @@ export class SeedConfig {
    * @type {number}
    */
   HOT_LOADER_PORT = 5578;
-  
+
   /**
    * The build interval which will force the TypeScript compiler to perform a typed compile run.
    * Between the typed runs, a typeless compile is run, which is typically much faster.

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -91,6 +91,17 @@ export class SeedConfig {
    * @type {number}
    */
   HOT_LOADER_PORT = 5578;
+  
+  /**
+   * The build interval which will force the TypeScript compiler to perform a typed compile run.
+   * Between the typed runs, a typeless compile is run, which is typically much faster.
+   * For example, if set to 5, the initial compile will be typed, followed by 5 typeless runs,
+   * then another typed run, and so on.
+   * If a compile error is encountered, the build will use typed compilation until the error is resolved.
+   * The default value is `0`, meaning typed compilation will always be performed.
+   * @type {number}
+   */
+  TYPED_COMPILE_INTERVAL = 0;
 
   /**
    * The directory where the bootstrap file is located.

--- a/tools/tasks/seed/build.js.dev.ts
+++ b/tools/tasks/seed/build.js.dev.ts
@@ -35,11 +35,10 @@ export = () => {
   if (typedBuildCounter < TYPED_COMPILE_INTERVAL) {
     isFullCompile = false;
     tsProject = makeTsProject({isolatedModules: true});
+    projectFiles = projectFiles.pipe(plugins.cached());
+    util.log('Performing typeless TypeScript compile.');
   } else {
     tsProject = makeTsProject();
-    if(TYPED_COMPILE_INTERVAL <= 0) {
-      projectFiles = projectFiles.pipe(plugins.cached());
-    }
     projectFiles = merge(typings, projectFiles);
   }
 
@@ -55,7 +54,6 @@ export = () => {
     typedBuildCounter = 0;
   } else {
     typedBuildCounter++;
-    util.log('Performing typeless TypeScript compile.');
   }
 
   return result.js

--- a/tools/tasks/seed/build.js.dev.ts
+++ b/tools/tasks/seed/build.js.dev.ts
@@ -1,19 +1,22 @@
 import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import * as merge from 'merge-stream';
+import * as util from 'gulp-util';
 import { join } from 'path';
 
-import { APP_DEST, APP_SRC, TOOLS_DIR } from '../../config';
+import { APP_DEST, APP_SRC, TOOLS_DIR, TYPED_COMPILE_INTERVAL } from '../../config';
 import { makeTsProject, templateLocals } from '../../utils';
 
 const plugins = <any>gulpLoadPlugins();
+
+let typedBuildCounter = TYPED_COMPILE_INTERVAL; // Always start with the typed build.
 
 /**
  * Executes the build process, transpiling the TypeScript files (except the spec and e2e-spec files) for the development
  * environment.
  */
 export = () => {
-  let tsProject = makeTsProject();
+  let tsProject: any;
   let typings = gulp.src([
     'typings/index.d.ts',
     TOOLS_DIR + '/manual_typings/**/*.d.ts'
@@ -24,11 +27,38 @@ export = () => {
     '!' + join(APP_SRC, '**/*.e2e-spec.ts')
   ];
 
-  let projectFiles = gulp.src(src).pipe(plugins.cached());
-  let result = merge(typings, projectFiles)
+  let projectFiles = gulp.src(src);
+  let result: any;
+  let isFullCompile = true;
+
+  // Only do a typed build every X builds, otherwise do a typeless build to speed things up
+  if (typedBuildCounter < TYPED_COMPILE_INTERVAL) {
+    isFullCompile = false;
+    tsProject = makeTsProject({isolatedModules: true});
+  }
+  else {
+    tsProject = makeTsProject();
+    if(TYPED_COMPILE_INTERVAL <= 0) {
+      projectFiles = projectFiles.pipe(plugins.cached());
+    }
+    projectFiles = merge(typings, projectFiles);
+  }
+
+  result = projectFiles
     .pipe(plugins.plumber())
     .pipe(plugins.sourcemaps.init())
-    .pipe(plugins.typescript(tsProject));
+    .pipe(plugins.typescript(tsProject))
+    .on('error', () => {
+      typedBuildCounter = TYPED_COMPILE_INTERVAL;
+    });
+
+  if (isFullCompile) {
+    typedBuildCounter = 0;
+  }
+  else {
+    typedBuildCounter++;
+    util.log('Performing typeless TypeScript compile.');
+  }
 
   return result.js
     .pipe(plugins.sourcemaps.write())

--- a/tools/tasks/seed/build.js.dev.ts
+++ b/tools/tasks/seed/build.js.dev.ts
@@ -35,8 +35,7 @@ export = () => {
   if (typedBuildCounter < TYPED_COMPILE_INTERVAL) {
     isFullCompile = false;
     tsProject = makeTsProject({isolatedModules: true});
-  }
-  else {
+  } else {
     tsProject = makeTsProject();
     if(TYPED_COMPILE_INTERVAL <= 0) {
       projectFiles = projectFiles.pipe(plugins.cached());
@@ -54,8 +53,7 @@ export = () => {
 
   if (isFullCompile) {
     typedBuildCounter = 0;
-  }
-  else {
+  } else {
     typedBuildCounter++;
     util.log('Performing typeless TypeScript compile.');
   }

--- a/tools/utils/seed/tsproject.ts
+++ b/tools/utils/seed/tsproject.ts
@@ -2,18 +2,19 @@ import * as gulpLoadPlugins from 'gulp-load-plugins';
 
 const plugins = <any>gulpLoadPlugins();
 
-let tsProject: any;
+let tsProjects: any = {};
 
 /**
  * Creates a TypeScript project with the given options using the gulp typescript plugin.
  * @param {Object} options - The additional options for the project configuration.
  */
-export function makeTsProject(options?: Object) {
-  if (!tsProject) {
-    const config = Object.assign({
+export function makeTsProject(options: Object = {}) {
+  let optionsHash = JSON.stringify(options);
+  if (!tsProjects[optionsHash]) {
+    let config = Object.assign({
       typescript: require('typescript')
     }, options);
-    tsProject = plugins.typescript.createProject('tsconfig.json', config);
+    tsProjects[optionsHash] = plugins.typescript.createProject('tsconfig.json', config);
   }
-  return tsProject;
+  return tsProjects[optionsHash];
 }


### PR DESCRIPTION
Here's the typeless compile option mentioned in #1098.

A few quick notes:

- For some reason, when I use the typeless interval option, I'm occasionally seeing this gulp-typescript message:
```
Could not find input file C:\Developer\Projects\Personal\angular2-seed\src\client\________________empty.ts. This is probably an issue of gulp-typescript.
Please report it at https://github.com/ivogabe/gulp-typescript/issues
Debug information:
sourceRoot = "C:/Developer/Projects/Personal/angular2-seed/src/client/"
sources = ["________________empty.ts"]
```
I believe it's actually an issue with gulp-typescript, possibly caused by having two TS projects in use. If you test this out and also see the above message, you'll have to decide whether we can live with that message popping up.

- The use of `plugins.cached()` is only used if the typeless interval is turned off (e.g. `0`). I'm not positive, but I think that using the cached plugin while alternating between compile runs could wind up having the typed run miss files that were changed during the typeless runs, allowing errors to potentially sneak through uncaught. Hopefully this makes sense, let me know if it doesn't.