### PR TITLE
Add APP_ASSETS to project.config.

### DIFF
--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -14,11 +14,18 @@ export class ProjectConfig extends SeedConfig {
     super();
     // this.APP_TITLE = 'Put name of your app here';
 
-    // Add third-party libraries to be injected/bundled.
+    // Add `NPM` third-party libraries to be injected/bundled.
     this.NPM_DEPENDENCIES = [
       ...this.NPM_DEPENDENCIES,
       // {src: 'jquery/dist/jquery.min.js', inject: 'libs'},
       // {src: 'lodash/lodash.min.js', inject: 'libs'},
+    ];
+
+    // Add `local` third-party libraries to be injected/bundled.
+    this.APP_ASSETS = [
+      ...this.APP_ASSETS,
+      // {src: `${this.APP_SRC}/your-path-to-lib/libs/jquery-ui.js`, inject: true, vendor: false}
+      // {src: `${this.CSS_SRC}/path-to-lib/test-lib.css`, inject: true, vendor: false},
     ];
 
     /* Add to or override NPM module configurations: */


### PR DESCRIPTION
Today when I had a question in **gitter** how to add an assets library, I saw that we don't have this one in our `project.config.ts`, many new developers don't know about this important property. So I add it there.