### PR TITLE
Fix relative path on build.prod

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -67,7 +67,8 @@ export class SeedConfig {
 
   /**
    * The path for the base of the application at runtime.
-   * The default path is `/`, which can be overriden by the `--base` flag when running `npm start`.
+   * The default path is based on the environment ('/' for development and '' for production),
+   * which can be overriden by the `--base` flag when running `npm start`.
    * @type {string}
    */
   APP_BASE = argv['base'] || (this.ENV === ENVIRONMENTS.DEVELOPMENT ? '/' : '');
@@ -435,6 +436,18 @@ export class SeedConfig {
     'gulp-sass': {
       includePaths: ['./node_modules/']
     },
+
+    /**
+     * The options to pass to gulp-concat-css
+     * Reference: https://github.com/mariocasciaro/gulp-concat-css
+     * @type {object}
+     */
+    'gulp-concat-css': {
+      targetFile: this.CSS_PROD_BUNDLE,
+      options: {
+        rebaseUrls: false
+      }
+    }
   };
 
   /**

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -70,7 +70,7 @@ export class SeedConfig {
    * The default path is `/`, which can be overriden by the `--base` flag when running `npm start`.
    * @type {string}
    */
-  APP_BASE = argv['base'] || '/';
+  APP_BASE = argv['base'] || (this.ENV === ENVIRONMENTS.DEVELOPMENT ? '/' : '');
 
   /**
    * The base path of node modules.

--- a/tools/tasks/seed/build.html_css.ts
+++ b/tools/tasks/seed/build.html_css.ts
@@ -10,7 +10,6 @@ import {
   APP_SRC,
   BROWSER_LIST,
   CSS_DEST,
-  CSS_PROD_BUNDLE,
   CSS_SRC,
   DEPENDENCIES,
   ENABLE_SCSS,
@@ -21,6 +20,7 @@ import {
 
 const plugins = <any>gulpLoadPlugins();
 const cleanCss = require('gulp-clean-css');
+const gulpConcatCssConfig = getPluginConfig('gulp-concat-css');
 
 const processors = [
   autoprefixer({
@@ -97,7 +97,7 @@ function processExternalStylesheets() {
  */
 function processAllExternalStylesheets() {
   return merge(getExternalCssStream(), getExternalScssStream())
-    .pipe(isProd ? plugins.concatCss(CSS_PROD_BUNDLE,{rebaseUrls: false}) : plugins.util.noop())
+    .pipe(isProd ? plugins.concatCss(gulpConcatCssConfig.targetFile, gulpConcatCssConfig.options) : plugins.util.noop())
     .pipe(plugins.postcss(processors))
     .pipe(isProd ? cleanCss() : plugins.util.noop())
     .pipe(gulp.dest(CSS_DEST));
@@ -143,7 +143,7 @@ function getExternalScss() {
 function processExternalCss() {
   return getExternalCssStream()
     .pipe(plugins.postcss(processors))
-    .pipe(isProd ? plugins.concatCss(CSS_PROD_BUNDLE,{rebaseUrls: false}) : plugins.util.noop())
+    .pipe(isProd ? plugins.concatCss(gulpConcatCssConfig.targetFile, gulpConcatCssConfig.options) : plugins.util.noop())
     .pipe(isProd ? cleanCss() : plugins.util.noop())
     .pipe(gulp.dest(CSS_DEST));
 }

--- a/tools/tasks/seed/build.html_css.ts
+++ b/tools/tasks/seed/build.html_css.ts
@@ -97,7 +97,7 @@ function processExternalStylesheets() {
  */
 function processAllExternalStylesheets() {
   return merge(getExternalCssStream(), getExternalScssStream())
-    .pipe(isProd ? plugins.concatCss(CSS_PROD_BUNDLE) : plugins.util.noop())
+    .pipe(isProd ? plugins.concatCss(CSS_PROD_BUNDLE,{rebaseUrls: false}) : plugins.util.noop())
     .pipe(plugins.postcss(processors))
     .pipe(isProd ? cleanCss() : plugins.util.noop())
     .pipe(gulp.dest(CSS_DEST));
@@ -143,7 +143,7 @@ function getExternalScss() {
 function processExternalCss() {
   return getExternalCssStream()
     .pipe(plugins.postcss(processors))
-    .pipe(isProd ? plugins.concatCss(CSS_PROD_BUNDLE) : plugins.util.noop())
+    .pipe(isProd ? plugins.concatCss(CSS_PROD_BUNDLE,{rebaseUrls: false}) : plugins.util.noop())
     .pipe(isProd ? cleanCss() : plugins.util.noop())
     .pipe(gulp.dest(CSS_DEST));
 }


### PR DESCRIPTION
This closes #1040, and closes #1107

Apparently it is possible now to run `npm run build.prod` and publish the generated `dist/prod` to a subsite like `http://www.site.com/subsite/` and every related path should be ok.