### PR TITLE
added templating to the build.js.test task

### DIFF
--- a/tools/tasks/seed/build.js.test.ts
+++ b/tools/tasks/seed/build.js.test.ts
@@ -3,7 +3,7 @@ import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join} from 'path';
 
 import { APP_DEST, APP_SRC, BOOTSTRAP_MODULE, TOOLS_DIR, ENABLE_SCSS } from '../../config';
-import { makeTsProject } from '../../utils';
+import { makeTsProject, templateLocals } from '../../utils';
 
 const plugins = <any>gulpLoadPlugins();
 
@@ -32,5 +32,6 @@ export = () => {
 
   return result.js
     .pipe(plugins.sourcemaps.write())
+    .pipe(plugins.template(templateLocals()))
     .pipe(gulp.dest(APP_DEST));
 };


### PR DESCRIPTION
When you run tests the config throws a parsing error.
The reason is that the templating wasn't activated for this flow yet.

Related to: https://github.com/mgechev/angular2-seed/issues/1048