### PR TITLE
fix(coverage): resolve issues preventing coverage/tests running correctly

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -1,4 +1,5 @@
 import * as gulp from 'gulp';
+import * as util from 'gulp-util';
 import * as runSequence from 'run-sequence';
 
 import { PROJECT_TASKS_DIR, SEED_TASKS_DIR } from './tools/config';
@@ -56,10 +57,11 @@ gulp.task('build.prod', (done: any) =>
 // --------------
 // Build test.
 gulp.task('build.test', (done: any) =>
-  runSequence('clean.dev',
+  runSequence('clean.once',
               'tslint',
               'build.assets.dev',
               'build.html_css',
+              'build.js.dev',
               'build.js.test',
               'build.index.dev',
               done));
@@ -116,3 +118,17 @@ gulp.task('test', (done: any) =>
   runSequence('build.test',
               'karma.start',
               done));
+
+// --------------
+// Clean dev/coverage that will only run once
+// this prevents karma watchers from being broken when directories are deleted
+let firstRun = true;
+gulp.task('clean.once', (done: any) => {
+  if (firstRun) {
+    firstRun = false;
+    runSequence('clean.dev', 'clean.coverage', done);
+  } else {
+    util.log('Skipping clean on rebuild');
+    done();
+  }
+})

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -106,9 +106,7 @@ module.exports = function(config) {
     coverageReporter: {
       dir: 'coverage/',
       reporters: [
-        { type: 'text-summary' },
-        { type: 'json', subdir: '.', file: 'coverage-final.json' },
-        { type: 'html' }
+        { type: 'json', subdir: '.', file: 'coverage-final.json' }
       ]
     },
 

--- a/src/client/app/+about/about.component.spec.ts
+++ b/src/client/app/+about/about.component.spec.ts
@@ -2,10 +2,8 @@ import { TestComponentBuilder } from '@angular/compiler/testing';
 import { disableDeprecatedForms, provideForms } from '@angular/forms';
 import { Component } from '@angular/core';
 import {
-  describe,
-  expect,
   inject,
-  it
+  async
 } from '@angular/core/testing';
 import { getDOM } from '@angular/platform-browser/src/dom/dom_adapter';
 
@@ -19,7 +17,7 @@ export function main() {
     beforeEach(() => { providerArr = [disableDeprecatedForms(), provideForms()]; });
 
     it('should work',
-      inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {
+      async(inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {
         tcb.overrideProviders(TestComponent, providerArr)
           .createAsync(TestComponent)
           .then((rootTC: any) => {
@@ -27,7 +25,7 @@ export function main() {
 
 	    expect(getDOM().querySelectorAll(aboutDOMEl, 'h2')[0].textContent).toEqual('Features');
           });
-        }));
+        })));
     });
 }
 

--- a/src/client/app/+home/home.component.spec.ts
+++ b/src/client/app/+home/home.component.spec.ts
@@ -2,10 +2,8 @@ import { Component, provide } from '@angular/core';
 import { TestComponentBuilder } from '@angular/compiler/testing';
 import { disableDeprecatedForms, provideForms } from '@angular/forms';
 import {
-  describe,
-  expect,
-  inject,
-  it
+  async,
+  inject
 } from '@angular/core/testing';
 import {
   BaseRequestOptions,
@@ -27,10 +25,11 @@ export function main() {
     beforeEach(() => { providerArr = [disableDeprecatedForms(), provideForms()]; });
 
     it('should work',
-      inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {
+      async(inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {
         tcb.overrideProviders(TestComponent, providerArr)
           .createAsync(TestComponent)
           .then((rootTC: any) => {
+
             rootTC.detectChanges();
 
             let homeInstance = rootTC.debugElement.children[0].componentInstance;
@@ -41,13 +40,13 @@ export function main() {
 
             homeInstance.newName = 'Minko';
             homeInstance.addName();
+
             rootTC.detectChanges();
 
             expect(getDOM().querySelectorAll(homeDOMEl, 'li').length).toEqual(1);
-
             expect(getDOM().querySelectorAll(homeDOMEl, 'li')[0].textContent).toEqual('Minko');
           });
-      }));
+      })));
   });
 }
 

--- a/src/client/app/+home/home.component.ts
+++ b/src/client/app/+home/home.component.ts
@@ -15,9 +15,9 @@ import { NameListService } from '../shared/index';
 })
 export class HomeComponent implements OnInit {
 
-  newName: string;
+  newName: string = '';
   errorMessage: string;
-  names: any[];
+  names: any[] = [];
 
   /**
    * Creates an instance of the HomeComponent with the injected

--- a/src/client/app/app.component.spec.ts
+++ b/src/client/app/app.component.spec.ts
@@ -1,24 +1,17 @@
-import { Component, ComponentResolver, Injector } from '@angular/core';
-import { Location } from '@angular/common';
+import { Component } from '@angular/core';
 import { disableDeprecatedForms, provideForms } from '@angular/forms';
 import { TestComponentBuilder } from '@angular/compiler/testing';
-import { SpyLocation } from '@angular/common/testing';
+
 import {
-  beforeEachProviders,
+  addProviders,
   async,
-  describe,
-  expect,
-  inject,
-  it
+  inject
 } from '@angular/core/testing';
 import {
-  UrlSerializer,
-  DefaultUrlSerializer,
-  RouterOutletMap,
-  Router,
-  ActivatedRoute,
   RouterConfig
 } from '@angular/router';
+
+import {provideFakeRouter} from '../testing/router/router-testing-providers';
 
 import { AppComponent } from './app.component';
 import { HomeComponent } from './+home/home.component';
@@ -30,35 +23,18 @@ export function main() {
     // Disable old forms
     let providerArr: any[];
 
-    beforeEach(() => { providerArr = [disableDeprecatedForms(), provideForms()]; });
+    beforeEach(() => {
+      providerArr = [disableDeprecatedForms(), provideForms()];
 
-    // Support for testing component that uses Router
-    beforeEachProviders(() => {
+      // Support for testing component that uses Router
       let config:RouterConfig = [
         {path: '', component: HomeComponent},
         {path: 'about', component: AboutComponent}
       ];
 
-      return [
-        RouterOutletMap,
-        {provide: UrlSerializer, useClass: DefaultUrlSerializer},
-        {provide: Location, useClass: SpyLocation},
-        {
-          provide: Router,
-          useFactory: (
-            resolver:ComponentResolver,
-            urlSerializer:UrlSerializer,
-            outletMap:RouterOutletMap,
-            location:Location,
-            injector:Injector) => {
-            const r = new Router(TestComponent, resolver, urlSerializer, outletMap, location, injector, config);
-//            r.initialNavigation();
-            return r;
-          },
-          deps: [ComponentResolver, UrlSerializer, RouterOutletMap, Location, Injector]
-        },
-        {provide: ActivatedRoute, useFactory: (r:Router) => r.routerState.root, deps: [Router]},
-      ];
+      addProviders([
+        provideFakeRouter(TestComponent, config)
+      ]);
     });
 
     it('should build without a problem',

--- a/src/client/testing/router/mock-location-strategy.ts
+++ b/src/client/testing/router/mock-location-strategy.ts
@@ -1,0 +1,76 @@
+/**
+ * Mock location strategy (until provided by @angular)
+ * Copied from https://github.com/angular/angular/blob/master/modules/%40angular/common/testing/mock_location_strategy.ts
+ */
+import {Injectable} from '@angular/core';
+import {LocationStrategy} from '@angular/common';
+import {ObservableWrapper, EventEmitter} from '@angular/core/src/facade/async';
+
+/**
+ * A mock implementation of {@link LocationStrategy} that allows tests to fire simulated
+ * location events.
+ */
+@Injectable()
+export class MockLocationStrategy extends LocationStrategy {
+  internalBaseHref: string = '/';
+  internalPath: string = '/';
+  internalTitle: string = '';
+  urlChanges: string[] = [];
+  /** @internal */
+  _subject: EventEmitter<any> = new EventEmitter();
+  constructor() { super(); }
+
+  simulatePopState(url: string): void {
+    this.internalPath = url;
+    ObservableWrapper.callEmit(this._subject, new MockPopStateEvent(this.path()));
+  }
+
+  path(includeHash: boolean = false): string { return this.internalPath; }
+
+  prepareExternalUrl(internal: string): string {
+    if (internal.startsWith('/') && this.internalBaseHref.endsWith('/')) {
+      return this.internalBaseHref + internal.substring(1);
+    }
+    return this.internalBaseHref + internal;
+  }
+
+  pushState(ctx: any, title: string, path: string, query: string): void {
+    this.internalTitle = title;
+
+    var url = path + (query.length > 0 ? ('?' + query) : '');
+    this.internalPath = url;
+
+    var externalUrl = this.prepareExternalUrl(url);
+    this.urlChanges.push(externalUrl);
+  }
+
+  replaceState(ctx: any, title: string, path: string, query: string): void {
+    this.internalTitle = title;
+
+    var url = path + (query.length > 0 ? ('?' + query) : '');
+    this.internalPath = url;
+
+    var externalUrl = this.prepareExternalUrl(url);
+    this.urlChanges.push('replace: ' + externalUrl);
+  }
+
+  onPopState(fn: (value: any) => void): void { ObservableWrapper.subscribe(this._subject, fn); }
+
+  getBaseHref(): string { return this.internalBaseHref; }
+
+  back(): void {
+    if (this.urlChanges.length > 0) {
+      this.urlChanges.pop();
+      var nextUrl = this.urlChanges.length > 0 ? this.urlChanges[this.urlChanges.length - 1] : '';
+      this.simulatePopState(nextUrl);
+    }
+  }
+
+  forward(): void { throw 'not implemented'; }
+}
+
+class MockPopStateEvent {
+  pop: boolean = true;
+  type: string = 'popstate';
+  constructor(public newUrl: string) {}
+}

--- a/src/client/testing/router/router-testing-providers.ts
+++ b/src/client/testing/router/router-testing-providers.ts
@@ -1,0 +1,39 @@
+/*
+temporary mock router provider until @angular provides one (currently not exported / experimental)
+copied from https://raw.githubusercontent.com/springboot-angular2-tutorial/angular2-app/master/src/shared/routes/router-testing-providers.ts
+*/
+import {Location, LocationStrategy} from '@angular/common';
+import {
+  RouterOutletMap,
+  UrlSerializer,
+  DefaultUrlSerializer,
+  Router,
+  ActivatedRoute,
+  RouterConfig
+} from '@angular/router';
+import {SpyLocation} from '@angular/common/testing';
+import {ComponentResolver, Injector, Type} from '@angular/core';
+import {MockLocationStrategy} from './mock-location-strategy';
+
+export const provideFakeRouter = (rootComponentType:Type, config:RouterConfig = []) => {
+  return [
+    RouterOutletMap,
+    {provide: UrlSerializer, useClass: DefaultUrlSerializer},
+    {provide: Location, useClass: SpyLocation},
+    {provide: LocationStrategy, useClass: MockLocationStrategy},
+    {
+      provide: Router,
+      useFactory: (resolver:ComponentResolver, urlSerializer:UrlSerializer,
+                   outletMap:RouterOutletMap, location:Location, injector:Injector) => {
+        return new Router(
+          rootComponentType, resolver, urlSerializer, outletMap, location, injector, config);
+      },
+      deps: [ComponentResolver, UrlSerializer, RouterOutletMap, Location, Injector]
+    },
+    {
+      provide: ActivatedRoute,
+      useFactory: (r:Router) => r.routerState.root,
+      deps: [Router]
+    },
+  ];
+};

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -66,6 +66,12 @@ export class SeedConfig {
   COVERAGE_PORT = argv['coverage-port'] || 4004;
 
   /**
+  * The path to the coverage output
+  * NB: this must match what is configured in ./karma.conf.js
+  */
+  COVERAGE_DIR = 'coverage';
+
+  /**
    * The path for the base of the application at runtime.
    * The default path is based on the environment ('/' for development and '' for production),
    * which can be overriden by the `--base` flag when running `npm start`.

--- a/tools/tasks/seed/build.js.test.ts
+++ b/tools/tasks/seed/build.js.test.ts
@@ -2,7 +2,7 @@ import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join} from 'path';
 
-import { APP_DEST, APP_SRC, BOOTSTRAP_MODULE, TOOLS_DIR, ENABLE_SCSS } from '../../config';
+import { APP_DEST, APP_SRC, TOOLS_DIR, ENABLE_SCSS } from '../../config';
 import { makeTsProject } from '../../utils';
 
 const plugins = <any>gulpLoadPlugins();
@@ -16,9 +16,7 @@ export = () => {
   let src = [
     'typings/index.d.ts',
     TOOLS_DIR + '/manual_typings/**/*.d.ts',
-    join(APP_SRC, '**/*.ts'),
-    '!' + join(APP_SRC, '**/*.e2e-spec.ts'),
-    '!' + join(APP_SRC, `${BOOTSTRAP_MODULE}.ts`)
+    join(APP_SRC, '**/*.spec.ts')
   ];
   let result = gulp.src(src)
     .pipe(plugins.plumber())

--- a/tools/tasks/seed/clean.all.ts
+++ b/tools/tasks/seed/clean.all.ts
@@ -1,7 +1,7 @@
-import { DIST_DIR } from '../../config';
+import { DIST_DIR, COVERAGE_DIR } from '../../config';
 import { clean } from '../../utils';
 
 /**
  * Executes the build process, cleaning all files within the `/dist` directory.
  */
-export = clean(DIST_DIR);
+export = clean([DIST_DIR, COVERAGE_DIR]);

--- a/tools/tasks/seed/clean.coverage.ts
+++ b/tools/tasks/seed/clean.coverage.ts
@@ -1,0 +1,7 @@
+import { COVERAGE_DIR } from '../../config';
+import { clean } from '../../utils';
+
+/**
+ * Executes the build process, cleaning all files within the `/dist/dev` directory.
+ */
+export = clean(COVERAGE_DIR);


### PR DESCRIPTION
here's a PR with what I did to get coverage working and the tests updated for RC4. 

after this update you should be able to run `npm test` and `npm run serve.coverage` and have it work as expected. karma should also be able to detect changes properly when running the watch task.

build updates:
update build.js.test task to only build the tests (different build paths invalidate the sourcemaps)
update gulp build.test task to only perform a clean on the initial build and to also run build.js.dev now
add a clean.coverage task and add it to the build.test task

test updates:
remove deprecated jasmine imports
add mock router/location strategy (until @angular provides one)
add default values to home.component so home component tests will pass.

not done:
figure out some way to run istanbul-remap whenever a karma run completes. 
