### PR TITLE
docs(tools-readme): update tools readme

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -20,6 +20,10 @@ The subfolders provide further folders to distinguish between files which are pr
 
 The configuration of the seed contains of a basic configuration provided by `/config/seed.config.ts` file. You can add your own custom configuration within the `/config/project.config.ts` file, which extends the seed configuration.
 
+## Environment Configuration
+
+The environment configuration files in `/tools/env` provide a way for you to set and override configuration settings based on a given environment. The `/tools/env/base.ts` configuration is set up in all environments (dev|test|staging|prod), whereas the `/tools/env/dev.ts` is specific to the dev environment, as is `/tools/env/prod.ts` specific to the prod environment.
+
 ## Manual Typings
 
 The `manual_typings` folder contains of manual TypeScript typings provided by the seed (`/manual_typings/seed`) and project specific TypeScript typings (`/manual_typings/project`). As for the project specific typings there is a sample provided (`/manual_typings/project/sample.package.d.ts`) to help you get started.
@@ -47,6 +51,7 @@ The seed provides the following tasks:
 | `build.js.tools.ts`    | Transpiles the TypeScript files located in `/tools` |
 | `check.versions.ts`    | Checks if the required Node and NPM (as defined in `/config/seed.config.ts`) are installed |
 | `clean.all.ts`         | Cleans all files within the `/dist` directory |
+| `clean.coverage.ts`    | Cleans all files within the `/coverage` directory |
 | `clean.dev.ts`         | Cleans all files within the `/dist/dev` directory |
 | `clean.prod.ts`        | Cleans all files within the `/dist/prod` directory |
 | `clean.tools.ts`       | Cleans all JavaScript files (which got transpiled from the TypeScript files) within the `/tools` directory  |
@@ -57,8 +62,8 @@ The seed provides the following tasks:
 | `karma.start.ts`       | Starts the unit tests using `karma` |
 | `serve.coverage.ts`    | Serves the unit test coverage report using an `express` server |
 | `serve.docs.ts`        | Serves the application documentation using an `express` server |
-| `serve.prod.ts`        | Serves the files from `/dist/prod` using an `express` server |
-| `serve.start.ts`       | Serves the files from `/dist/dev` using an `express` server |
+| `server.prod.ts`       | Serves the files from `/dist/prod` using an `express` server |
+| `server.start.ts`      | Serves the files from `/dist/dev` using an `express` server |
 | `tslint.ts`            | Lints the TypeScript files using `codelyzer` |
 | `watch.dev.ts`         | Watches for code changes and rebuilds the files in `/dist/dev` |
 | `watch.e2e.ts`         | Watches for code changes and rebuilds the files in `/dist/e2e` |


### PR DESCRIPTION
Update the REAMDE.md in /tools, adding the missing task description
for the `clean.coverage` task and correct the
misspelling for the `server.prod` and `server.start` task.