### PR TITLE
refactor(tsconfig): move properties to tsconfig

### DIFF
--- a/src/client/tsconfig.json
+++ b/src/client/tsconfig.json
@@ -16,5 +16,14 @@
     "noImplicitUseStrict": false,
     "noFallthroughCasesInSwitch": true
   },
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.e2e-spec.ts"
+  ],
+  "files": [
+    "**/*.ts",
+    "../../typings/index.d.ts",
+    "../../tools/manual_typings/**/*.d.ts"
+  ],
   "compileOnSave": false
 }


### PR DESCRIPTION
Move the properties for the files to be used to build
the typescript project to the `/src/client/tsconfig.json`.

Fixes #1184 

This is a the first part of the fix for #1184, appling the necessary `files` and `excludes` options to the `src/client/tsconfig.json`.

**Tasks:**
- [X] Update `src/client/tsconfig.json` => *Review please* 
- [ ] Updating the `tools/tasks/seed/build.js.dev.ts` following the lines along https://github.com/mgechev/angular2-seed/blob/master/tools/tasks/seed/build.js.dev.ts#L20

Paging @mgechev, @ludohenin for help on this. 