### PR TITLE
chore(.gitignore): add OS X trash file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ tmp
 gulpfile.js
 gulpfile.js.map
 
+# OS X trash files
+.DS_Store
+


### PR DESCRIPTION
Hi,

As I cloned the repository many times and always added .DS_Store
to my .gitignore, I thought it would be smarter to submit it.
Changes do not affect structure or code.

Regards,