### PR TITLE
fix: npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "serve.dev": "gulp serve.dev --color --config-env dev",
     "serve.e2e": "gulp serve.e2e --color",
     "serve.prod": "gulp serve.prod --color --config-env prod",
-    "start": "gulp serve.dev --color --config-env dev",
+    "start": "gulp serve.dev --color",
     "tasks.list": "gulp --tasks-simple --color",
     "test": "gulp test --color",
     "e2e.ci": "gulp build.prod --color && gulp build.js.e2e --color && gulp e2e --color",


### PR DESCRIPTION
`config-env dev` is the default so no need to add it here.

Maybe the tools would deserve a `serve` task so we could simply do thing like:
* `npm start -- --serve prod --config-env dev`
* `npm start -- --serve e2e`