### PR TITLE
docs: updated README.md for EMFILE error when using test.watch (#1233)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ npm test
 # Development. Your app will be watched by karma
 # on each change all your specs will be executed.
 npm run test.watch
+# NB: The command above might fail with a "EMFILE: too many open files" error.
+# Some OS have a small limit of opened file descriptors (256) by default
+# and will result in the EMFILE error.
+# You can raise the maximum of file descriptors by running the command below:
+ulimit -n 10480
+
 
 # code coverage (istanbul)
 # auto-generated at the end of `npm test`


### PR DESCRIPTION
Modified README: additional command to run to prevent "too many open files" when running test.watch