### PR TITLE
Karma watch waits for an available file handler

### DIFF
--- a/tools/tasks/seed/karma.watch.ts
+++ b/tools/tasks/seed/karma.watch.ts
@@ -2,8 +2,12 @@ import { startKarma } from '../../utils/seed/karma.start';
 /**
  * Executes the build process, running all unit tests using `karma`.
  */
-export = (done: any) => {
+export = (done: any) => setTimeout(() => {
   return startKarma(done, {
     singleRun: false
   });
-};
+},
+// On some OS, the default max opened file descriptor limit might cause karma to not start.
+// By setting this timeout, there should be enough time before other tasks release the descriptors.
+// Karma itself can have as many opened files as it needs, it uses graceful-fs.
+1000);


### PR DESCRIPTION
Karma watch must wait before file descriptors are available before starting

[Issue #1285](https://github.com/mgechev/angular2-seed/issues/1285)