### PR TITLE
Log exception message instead of generic error message

### DIFF
--- a/tools/utils/seed/template_locals.ts
+++ b/tools/utils/seed/template_locals.ts
@@ -11,10 +11,9 @@ const getConfig = (path: string, env: string): any => {
     config = require(configPath);
   } catch (e) {
     config = null;
+    util.log(util.colors.red(e.message));
   }
-  if (!config) {
-    util.log(util.colors.red(`Cannot find ${configPath}`));
-  }
+
   return config;
 };
 


### PR DESCRIPTION
It is better to log the actual error message, because a exception can have different causes. 

For example: In the current implementation a syntax error, in a config file, will produce 'Cannot find ${configPath}'. Because this is misleading, this commit changes the behavior to log the actual exception message (f. e. 'Unable to compile TypeScript').