### PR TITLE
Skip main-prod.ts in non-AoT build for multi-app scenario. Fix for #1305

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -135,8 +135,9 @@ export class SeedConfig {
 
   BOOTSTRAP_PROD_MODULE = `${this.BOOTSTRAP_DIR}/` + 'main';
 
+  NG_FACTORY_FILE = 'main-prod';
 
-  BOOTSTRAP_FACTORY_PROD_MODULE = `${this.BOOTSTRAP_DIR}/` + 'main-prod';
+  BOOTSTRAP_FACTORY_PROD_MODULE = `${this.BOOTSTRAP_DIR}/${this.NG_FACTORY_FILE}`;
   /**
    * The default title of the application as used in the `<title>` tag of the
    * `index.html`.

--- a/tools/tasks/seed/build.js.dev.ts
+++ b/tools/tasks/seed/build.js.dev.ts
@@ -8,7 +8,7 @@ import {
   APP_DEST,
   SYSTEM_CONFIG_DEV,
   APP_SRC,
-  BOOTSTRAP_FACTORY_PROD_MODULE,
+  NG_FACTORY_FILE,
   /*PROJECT_ROOT, */TOOLS_DIR,
   TYPED_COMPILE_INTERVAL
 } from '../../config';
@@ -34,7 +34,7 @@ export = () => {
     join(APP_SRC, '**/*.ts'),
     '!' + join(APP_SRC, '**/*.spec.ts'),
     '!' + join(APP_SRC, '**/*.e2e-spec.ts'),
-    '!' + join(APP_SRC, `**/${BOOTSTRAP_FACTORY_PROD_MODULE}.ts`)
+    '!' + join(APP_SRC, `**/${NG_FACTORY_FILE}.ts`)
   ];
 
   let projectFiles = gulp.src(src);

--- a/tools/tasks/seed/build.js.e2e.ts
+++ b/tools/tasks/seed/build.js.e2e.ts
@@ -5,7 +5,7 @@ import { join } from 'path';
 import {
   APP_DEST,
   APP_SRC,
-  BOOTSTRAP_FACTORY_PROD_MODULE,
+  NG_FACTORY_FILE,
   SYSTEM_CONFIG_DEV,
   TOOLS_DIR
 } from '../../config';
@@ -25,7 +25,7 @@ export = () => {
     TOOLS_DIR + '/manual_typings/**/*.d.ts',
     join(APP_SRC, '**/*.ts'),
     '!' + join(APP_SRC, '**/*.spec.ts'),
-    '!' + join(APP_SRC, `**/${BOOTSTRAP_FACTORY_PROD_MODULE}.ts`)
+    '!' + join(APP_SRC, `**/${NG_FACTORY_FILE}.ts`)
   ];
   let result = gulp.src(src)
     .pipe(plugins.plumber())

--- a/tools/tasks/seed/build.js.prod.ts
+++ b/tools/tasks/seed/build.js.prod.ts
@@ -2,7 +2,7 @@ import * as gulp from 'gulp';
 import * as gulpLoadPlugins from 'gulp-load-plugins';
 import { join } from 'path';
 
-import { BOOTSTRAP_FACTORY_PROD_MODULE, TMP_DIR, TOOLS_DIR } from '../../config';
+import { NG_FACTORY_FILE, TMP_DIR, TOOLS_DIR } from '../../config';
 import { makeTsProject, templateLocals } from '../../utils';
 
 const plugins = <any>gulpLoadPlugins();
@@ -23,13 +23,13 @@ export = () => {
     'typings/index.d.ts',
     TOOLS_DIR + '/manual_typings/**/*.d.ts',
     join(TMP_DIR, '**/*.ts'),
-    '!' + join(TMP_DIR, `**/${BOOTSTRAP_FACTORY_PROD_MODULE}.ts`)
+    '!' + join(TMP_DIR, `**/${NG_FACTORY_FILE}.ts`)
   ];
   let result = gulp.src(src)
     .pipe(plugins.plumber())
     .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
     .pipe(plugins.typescript(tsProject))
-    .once('error', (e: any) => {
+    .once('error', function(e: any) {
       this.once('finish', () => process.exit(1));
     });
 


### PR DESCRIPTION
In case of multi-app scenario, non AoT builds will skip only main app's main-prod.ts file. This commit will ensure that all main-prod.ts in APP_SRC will be skipped in transpiling process (build.js.dev, build.js.prod and build.js.e2e)