### PR TITLE
"es6-module-loader": "^0.17.8, is deprecated.

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@angular/platform-browser-dynamic": "2.0.0-rc.6",
     "@angular/router": "3.0.0-rc.2",
     "core-js": "^2.4.0",
-    "es6-module-loader": "^0.17.8",
+    "es-module-loader": "^1.0.0",
     "reflect-metadata": "^0.1.8",
     "rxjs": "5.0.0-beta.11",
     "systemjs": "0.19.27",


### PR DESCRIPTION
`"es6-module-loader": "^0.17.8",` is deprecated and should be changed to `"es-module-loader": "^1.0.0",`