### PR TITLE
handle endponts with '.' in dev environemnt (browser-sync middleware)…

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "colorguard": "^1.2.0",
     "compression": "^1.6.2",
     "connect": "^3.4.1",
-    "connect-history-api-fallback": "^1.2.0",
+    "connect-history-api-fallback": "^1.3.0",
     "connect-livereload": "^0.5.4",
     "cssnano": "^3.7.3",
     "deep-extend": "^0.4.1",

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -436,6 +436,25 @@ export class SeedConfig {
   COLOR_GUARD_WHITE_LIST: [string, string][] = [
   ];
 
+  protected DEV_REWRITE_RULES = [
+    {
+      from: /^\/node_modules\/.*$/,
+      to: (context:any) => context.parsedUrl.pathname
+    },
+    {
+      from: /^\/app\/.*$/,
+      to: (context:any) => context.parsedUrl.pathname
+    },
+    {
+      from: /^\/assets\/.*$/,
+      to: (context:any) => context.parsedUrl.pathname
+    },
+    {
+      from: /^\/css\/.*$/,
+      to: (context:any) => context.parsedUrl.pathname
+    }
+  ];
+
   /**
    * Configurations for NPM module configurations. Add to or override in project.config.ts.
    * If you like, use the mergeObject() method to assist with this.
@@ -449,7 +468,11 @@ export class SeedConfig {
      * @type {any}
      */
     'browser-sync': {
-      middleware: [require('connect-history-api-fallback')({ index: `${this.APP_BASE}index.html` })],
+      middleware: [require('connect-history-api-fallback')({
+        index: `${this.APP_BASE}index.html`,
+        rewrites: this.DEV_REWRITE_RULES,
+        disableDotRule: true
+      })],
       port: this.PORT,
       startPath: this.APP_BASE,
       open: argv['b'] ? false : true,


### PR DESCRIPTION
Fix for #1269. Adding rewrite rules for connect-history-api-fallback middleware to serve static file as it is and disable dot checking