### PR TITLE
fix(build.assets.prod) excluding tsconfig.json

### DIFF
--- a/tools/tasks/seed/build.assets.prod.ts
+++ b/tools/tasks/seed/build.assets.prod.ts
@@ -22,6 +22,7 @@ var onlyDirs = function (es: any) {
 export = () => {
   return gulp.src([
     join(Config.APP_SRC, '**'),
+    '!' + join(Config.APP_SRC, 'tsconfig.json'),
     '!' + join(Config.APP_SRC, '**', '*.ts'),
     '!' + join(Config.APP_SRC, '**', '*.css'),
     '!' + join(Config.APP_SRC, '**', '*.html'),


### PR DESCRIPTION
When running `build.prod` the `tsconfig.json` file was copied over into `dist/prod`. This file can be excluded.