### PR TITLE
Fix for Issue "#1366: Protractor typings"

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/protractor": "^1.5.18",
     "@types/rimraf": "^0.0.27",
     "@types/run-sequence": "^0.0.27",
-    "@types/selenium-webdriver": "^2.44.28",
+    "@types/selenium-webdriver": "2.44.*",
     "@types/systemjs": "^0.19.30",
     "@types/yargs": "^0.0.30",
     "@types/zone.js": "^0.0.26",

--- a/src/client/tsconfig.json
+++ b/src/client/tsconfig.json
@@ -16,8 +16,8 @@
     "noImplicitUseStrict": false,
     "noFallthroughCasesInSwitch": true,
     "typeRoots": [
-      "../../node_modules",
-      "../../node_modules/@types"
+      "../../node_modules/@types",
+      "../../node_modules"
     ],
     "types": [
       "core-js",


### PR DESCRIPTION
This pull request fixes issues mentioned in issue #1366 Protractor Typings.
Reversed the recent commit to the src/client/tsconfig.json which broke the build.
This was presenting itself as many errors of the form: "error TS2300: Duplicate identifier ..."
The 2.53 version of the @types/selenium-webdriver breaks compatibility with version 2.44.
This breaking change wrecked the build for protractor, so I pinned the version to 2.44.*.
