### PR TITLE
copy tsconfig.json to tmp dir

### DIFF
--- a/tools/tasks/seed/build.js.prod.exp.ts
+++ b/tools/tasks/seed/build.js.prod.exp.ts
@@ -12,7 +12,7 @@ const plugins = <any>gulpLoadPlugins();
  */
 
 export = () => {
-  let tsProject = makeTsProject();
+  let tsProject = makeTsProject({}, Config.TMP_DIR);
   let src = [
     Config.TOOLS_DIR + '/manual_typings/**/*.d.ts',
     join(Config.TMP_DIR, '**/*.ts')

--- a/tools/tasks/seed/build.js.prod.ts
+++ b/tools/tasks/seed/build.js.prod.ts
@@ -18,7 +18,7 @@ const INLINE_OPTIONS = {
  */
 
 export = () => {
-  let tsProject = makeTsProject();
+  let tsProject = makeTsProject({}, Config.TMP_DIR);
   let src = [
     Config.TOOLS_DIR + '/manual_typings/**/*.d.ts',
     join(Config.TMP_DIR, '**/*.ts'),

--- a/tools/tasks/seed/copy.prod.ts
+++ b/tools/tasks/seed/copy.prod.ts
@@ -12,6 +12,7 @@ export = () => {
       join(Config.APP_SRC, '**/*.html'),
       join(Config.APP_SRC, '**/*.css'),
       join(Config.APP_SRC, '**/*.json'),
+      join(Config.APP_SRC, '*.json'),
       '!' + join(Config.APP_SRC, '**/*.spec.ts'),
       '!' + join(Config.APP_SRC, '**/*.e2e-spec.ts')
     ])

--- a/tools/utils/seed/tsproject.ts
+++ b/tools/utils/seed/tsproject.ts
@@ -11,14 +11,14 @@ let tsProjects: any = {};
  * Creates a TypeScript project with the given options using the gulp typescript plugin.
  * @param {Object} options - The additional options for the project configuration.
  */
-export function makeTsProject(options: Object = {}) {
+export function makeTsProject(options: Object = {}, pathToTsConfig: string = Config.APP_SRC) {
   let optionsHash = JSON.stringify(options);
   if (!tsProjects[optionsHash]) {
     let config = Object.assign({
       typescript: require('typescript')
     }, options);
     tsProjects[optionsHash] =
-      plugins.typescript.createProject(join(Config.APP_SRC, 'tsconfig.json'), config);
+      plugins.typescript.createProject(join(pathToTsConfig, 'tsconfig.json'), config);
   }
   return tsProjects[optionsHash];
 }


### PR DESCRIPTION
In order to make use of the Typescript 2 feature of BaseUrl and Path mappings, it seems necessary to copy the tsconfig.json file to the tmp dir.

We got the error message `error TS2345: Argument of type 'Session' is not assignable to parameter of type 'BaseModel'.  Property 'propertyMap' is protected but type 'BaseModel' is not a class derived from 'BaseModel'.` which seems to be caused because of the following configuration in tsconfig.json:
```
    "baseUrl": "./src/client",
    "paths": {
      "shared/*": [
        "app/shared/*"
      ],
      "core/*": [
        "app/core/*"
      ]
    }
```

Because tsconfig.json is located in src/client, it takes all imports starting with `shared` from the src/client folder and not from tmp. Which seems to cause that the types don't match.

If tsconfig.json is located in tmp, then it will take the right files.
