### PR TITLE
Add all needed rxjs/ngrx operators to one central file

### DIFF
--- a/src/client/app/app.component.ts
+++ b/src/client/app/app.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { Config} from './shared/index';
+import './operators';
 
 /**
  * This class represents the main application component. Within the @Routes annotation is the configuration of the

--- a/src/client/app/home/home.component.ts
+++ b/src/client/app/home/home.component.ts
@@ -37,10 +37,10 @@ export class HomeComponent implements OnInit {
    */
   getNames() {
     this.nameListService.get()
-		     .subscribe(
-		       names => this.names = names,
-		       error =>  this.errorMessage = <any>error
-		       );
+      .subscribe(
+        names => this.names = names,
+        error =>  this.errorMessage = <any>error
+      );
   }
 
   /**

--- a/src/client/app/operators.ts
+++ b/src/client/app/operators.ts
@@ -1,8 +1,5 @@
 // rxjs
-// Statics
 //import 'rxjs/add/observable/throw';
-
-// Operators
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 

--- a/src/client/app/operators.ts
+++ b/src/client/app/operators.ts
@@ -1,0 +1,10 @@
+// rxjs
+// Statics
+//import 'rxjs/add/observable/throw';
+
+// Operators
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/catch';
+
+// ngrx
+//import '@ngrx/core/add/operator/select';

--- a/src/client/app/shared/name-list/name-list.service.ts
+++ b/src/client/app/shared/name-list/name-list.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/catch';
 
 /**
  * This class provides the NameList service with methods to read names and add names.

--- a/tools/manual_typings/seed/operators.d.ts
+++ b/tools/manual_typings/seed/operators.d.ts
@@ -1,0 +1,1 @@
+import '../../../src/client/app/operators';


### PR DESCRIPTION
RXJS/NGRX operators must be added to the application by importing them like ` import 'rxjs/add/operator/map';`. If, like in our application, operators are used a lot, they have to be imported often.

We would like to have one central place where all needed operators are added. Because those operators might be used in tests as well, their types definitions must be available in `build.js.test.ts`. For this purpose I import the operator definitions in a manual typings file.

Are there better solutions for this?