### PR TITLE
Moved karma reporters config from task to config for easier customization

### DIFF
--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -73,6 +73,22 @@ export class SeedConfig {
   COVERAGE_DIR = 'coverage';
 
   /**
+   * Karma reporter configuration
+   */
+  KARMA_REPORTERS = {
+    preprocessors: {
+      'dist/**/!(*spec).js': ['coverage']
+    },
+    reporters: ['mocha', 'coverage'],
+    coverageReporter: {
+      dir: this.COVERAGE_DIR + '/',
+      reporters: [
+        {type: 'json', subdir: '.', file: 'coverage-final.json'}
+      ]
+    }
+  };
+
+  /**
    * The path for the base of the application at runtime.
    * The default path is based on the environment '/',
    * which can be overriden by the `--base` flag when running `npm start`.

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -75,7 +75,7 @@ export class SeedConfig {
   /**
    * Karma reporter configuration
    */
-  KARMA_REPORTERS = {
+  KARMA_REPORTERS: any = {
     preprocessors: {
       'dist/**/!(*spec).js': ['coverage']
     },

--- a/tools/tasks/seed/karma.run.ts
+++ b/tools/tasks/seed/karma.run.ts
@@ -1,18 +1,9 @@
 import { startKarma } from '../../utils/seed/karma.start';
+import Config from '../../config';
+
 /**
  * Executes the build process, running all unit tests using `karma`.
  */
 export = (done: any) => {
-  return startKarma(done, {
-    preprocessors: {
-      'dist/**/!(*spec).js': ['coverage']
-    },
-    reporters: ['mocha', 'coverage'],
-    coverageReporter: {
-      dir: 'coverage/',
-      reporters: [
-        { type: 'json', subdir: '.', file: 'coverage-final.json' }
-      ]
-    },
-  });
+  return startKarma(done, Config.KARMA_REPORTERS);
 };


### PR DESCRIPTION
In order to keep the build tasks up-to-date with the seed project, it is easier to have all customization options in the config.