### PR TITLE
Exclude *.routes.ts from test coverage

### DIFF
--- a/tools/tasks/seed/karma.run.with_coverage.ts
+++ b/tools/tasks/seed/karma.run.with_coverage.ts
@@ -16,7 +16,7 @@ let repeatableStartKarma = (done: any, config: any = {}) => {
 export = (done: any) => {
   return repeatableStartKarma(done, {
     preprocessors: {
-      'dist/**/!(*spec|index|*.module).js': ['coverage']
+      'dist/**/!(*spec|index|*.module|*.routes).js': ['coverage']
     },
     reporters: ['mocha', 'coverage', 'karma-remap-istanbul'],
     coverageReporter: {

--- a/tools/tasks/seed/serve.coverage.watch.ts
+++ b/tools/tasks/seed/serve.coverage.watch.ts
@@ -13,6 +13,7 @@ export = () => {
       baseDir: './' + coverageFolder
     },
     port: Config.COVERAGE_PORT,
-    files: watchedFiles
+    files: watchedFiles,
+    logFileChanges: false
   });
 };


### PR DESCRIPTION
These scaffolding files also skew with the test coverage. Related to #1406