### PR TITLE
chore: ignore ts-node folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
 node_modules
 typings
+ts-node
 
 # Users Environment Variables
 .lock-wscript


### PR DESCRIPTION
ts-node is installed locally, is not necessary to track ts-node folder