### PR TITLE
fix(sass): not moving .sass files to dist/* folder

### DIFF
--- a/tools/tasks/seed/build.assets.dev.ts
+++ b/tools/tasks/seed/build.assets.dev.ts
@@ -11,7 +11,8 @@ export = () => {
   let paths: string[] = [
     join(Config.APP_SRC, '**'),
     '!' + join(Config.APP_SRC, '**', '*.ts'),
-    '!' + join(Config.APP_SRC, '**', '*.scss')
+    '!' + join(Config.APP_SRC, '**', '*.scss'),
+    '!' + join(Config.APP_SRC, '**', '*.sass')
   ].concat(Config.TEMP_FILES.map((p) => { return '!' + p; }));
 
   return gulp.src(paths)

--- a/tools/tasks/seed/build.assets.prod.ts
+++ b/tools/tasks/seed/build.assets.prod.ts
@@ -27,6 +27,7 @@ export = () => {
     '!' + join(Config.APP_SRC, '**', '*.css'),
     '!' + join(Config.APP_SRC, '**', '*.html'),
     '!' + join(Config.APP_SRC, '**', '*.scss'),
+    '!' + join(Config.APP_SRC, '**', '*.sass'),
     '!' + join(Config.ASSETS_SRC, '**', '*.js')
   ].concat(Config.TEMP_FILES.map((p) => { return '!' + p; })))
     .pipe(onlyDirs(es))


### PR DESCRIPTION
The seed is already dealing with scss files but not with sass files. Since the functionality is already there to use sass files with the seed, it would be nice to handle them as well.