### PR TITLE
Bump version of systemjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "es-module-loader": "^1.0.0",
     "reflect-metadata": "^0.1.8",
     "rxjs": "5.0.0-beta.12",
-    "systemjs": "0.19.38",
+    "systemjs": "0.19.39",
     "zone.js": "0.6.25"
   }
 }


### PR DESCRIPTION
[systemjs](https://www.npmjs.com/package/systemjs) is now at v0.19.39. Let's use it!