### PR TITLE
fix(build): allow start with differents environments

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -5,10 +5,18 @@ import * as runSequence from 'run-sequence';
 import Config from './tools/config';
 import { loadTasks } from './tools/utils';
 
+let ENV = Config.ENV || 'dev';
 
 loadTasks(Config.SEED_TASKS_DIR);
 loadTasks(Config.PROJECT_TASKS_DIR);
 
+
+// --------------
+// Serve env
+gulp.task('serve.env', (done: any) =>
+  runSequence('build.'+ENV,
+              'serve.'+ENV,
+              done));
 
 // --------------
 // Build dev.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "serve.dev": "gulp serve.dev --color --config-env dev",
     "serve.e2e": "gulp serve.e2e --color",
     "serve.prod": "gulp serve.prod --color --config-env prod",
-    "start": "gulp serve.dev --color",
+    "start": "gulp serve.env --color",
     "start.deving": "gulp start.deving --color",
     "tasks.list": "gulp --tasks-simple --color",
     "test": "gulp test --color",

--- a/tools/config/seed.config.ts
+++ b/tools/config/seed.config.ts
@@ -591,7 +591,7 @@ function appVersion(): number | string {
 function getEnvironment() {
   let base: string[] = argv['_'];
   let prodKeyword = !!base.filter(o => o.indexOf(ENVIRONMENTS.PRODUCTION) >= 0).pop();
-  let env = (argv['env'] || '').toLowerCase();
+  let env = (argv['config-env'] || '').toLowerCase();
   if ((base && prodKeyword) || env === ENVIRONMENTS.PRODUCTION) {
     return ENVIRONMENTS.PRODUCTION;
   } else {


### PR DESCRIPTION
Actually is not possible run the command `npm start -- --config-env prod`  because `npm script` executes  `"start": "gulp serve.dev --color"`